### PR TITLE
refactor(scoping): remove outdated code

### DIFF
--- a/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/scoping/SafeDSScopeProvider.kt
+++ b/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/scoping/SafeDSScopeProvider.kt
@@ -102,17 +102,14 @@ class SafeDSScopeProvider : AbstractSafeDSScopeProvider() {
         val packageName = context.containingCompilationUnitOrNull()?.qualifiedNameOrNull()
 
         // Declarations in other files
-        var result: IScope = FilteringScope(
+        val result: IScope = FilteringScope(
             super.delegateGetScope(context, SafeDSPackage.Literals.SDS_GOAL_REFERENCE__DECLARATION)
         ) {
             it.isReferencableExternalDeclaration(resource, packageName)
         }
 
         // Declarations in this file
-        result = declarationsInSameFile(resource, result)
-
-        // Declarations in this package
-        return declarationsInSamePackageDeclaration(resource, result)
+        return declarationsInSameFile(resource, result)
     }
 
     private fun scopeForReferenceDeclaration(context: SdsReference): IScope {
@@ -132,9 +129,6 @@ class SafeDSScopeProvider : AbstractSafeDSScopeProvider() {
 
                 // Declarations in this file
                 result = declarationsInSameFile(resource, result)
-
-                // Declarations in this package
-                result = declarationsInSamePackageDeclaration(resource, result)
 
                 // Declarations in containing classes
                 context.containingClassOrNull()?.let {
@@ -230,25 +224,6 @@ class SafeDSScopeProvider : AbstractSafeDSScopeProvider() {
     }
 
     private fun declarationsInSameFile(resource: Resource, parentScope: IScope): IScope {
-        if (resource.compilationUnitOrNull() != null) {
-            return Scopes.scopeFor(
-                emptyList(),
-                parentScope
-            )
-        }
-
-        val members = resource.compilationUnitOrNull()
-            ?.members
-            ?.filter { it !is SdsAnnotation && it !is SdsWorkflow }
-            ?: emptyList()
-
-        return Scopes.scopeFor(
-            members,
-            parentScope
-        )
-    }
-
-    private fun declarationsInSamePackageDeclaration(resource: Resource, parentScope: IScope): IScope {
         val members = resource.compilationUnitOrNull()
             ?.members
             ?.filter { it !is SdsAnnotation && it !is SdsWorkflow }

--- a/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/scoping/SafeDSScopeProvider.kt
+++ b/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/scoping/SafeDSScopeProvider.kt
@@ -149,7 +149,6 @@ class SafeDSScopeProvider : AbstractSafeDSScopeProvider() {
         fromResource: Resource,
         fromPackageWithQualifiedName: QualifiedName?
     ): Boolean {
-
         // Resolution failed in delegate scope
         if (this == null) return false
 
@@ -246,7 +245,6 @@ class SafeDSScopeProvider : AbstractSafeDSScopeProvider() {
     }
 
     private fun localDeclarations(context: EObject, parentScope: IScope): IScope {
-
         // Placeholders
         val placeholders = when (val containingStatement = context.closestAncestorOrNull<SdsAbstractStatement>()) {
             null -> emptyList()
@@ -265,7 +263,6 @@ class SafeDSScopeProvider : AbstractSafeDSScopeProvider() {
         val localDeclarations = placeholders + parameters
 
         return when (containingCallable) {
-
             // Lambdas can be nested
             is SdsAbstractLambda -> Scopes.scopeFor(
                 localDeclarations,


### PR DESCRIPTION
Closes #90.

### Summary of Changes

While #90 did not have any effect on the result of the scoping provider, the code was still confusing.  This confusing code is now removed.
