### PR TITLE
refactor: replace Tablesaw with kotlinx.dataframe

### DIFF
--- a/DSL/com.larsreimann.safeds/build.gradle.kts
+++ b/DSL/com.larsreimann.safeds/build.gradle.kts
@@ -121,14 +121,14 @@ sourceSets {
             "**/*.sdsflow",
             "**/*.sdsstub",
             "**/*.tokens",
-            "**/*.xtextbin"
+            "**/*.xtextbin",
         )
         resources.srcDirs("src-gen")
         resources.include(
             "**/*.sdsflow",
             "**/*.sdsstub",
             "**/*.tokens",
-            "**/*.xtextbin"
+            "**/*.xtextbin",
         )
     }
 }
@@ -141,7 +141,7 @@ val koverExcludes = listOf(
     "com.larsreimann.safeds.serializer.AbstractSafeDSSyntacticSequencer",
     "com.larsreimann.safeds.services.*",
     "com.larsreimann.safeds.safeDS.*",
-    "com.larsreimann.safeds.testing.*"
+    "com.larsreimann.safeds.testing.*",
 )
 
 tasks {

--- a/DSL/com.larsreimann.safeds/build.gradle.kts
+++ b/DSL/com.larsreimann.safeds/build.gradle.kts
@@ -97,7 +97,7 @@ dependencies {
     api(platform("org.eclipse.xtext:xtext-dev-bom:$xtextVersion"))
     implementation("org.eclipse.xtext:org.eclipse.xtext:$xtextVersion")
 
-    implementation("tech.tablesaw:tablesaw-core:0.43.1")
+    implementation("org.jetbrains.kotlinx:dataframe:0.8.0")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")

--- a/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/staticAnalysis/schema/SchemaComputer.kt
+++ b/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/staticAnalysis/schema/SchemaComputer.kt
@@ -4,41 +4,33 @@ import com.larsreimann.safeds.emf.createSdsColumn
 import com.larsreimann.safeds.emf.createSdsNamedType
 import com.larsreimann.safeds.emf.createSdsSchema
 import com.larsreimann.safeds.emf.createSdsString
-import com.larsreimann.safeds.safeDS.SdsColumn
 import com.larsreimann.safeds.safeDS.SdsSchema
 import com.larsreimann.safeds.stdlibAccess.StdlibClasses
 import com.larsreimann.safeds.stdlibAccess.getStdlibClassOrNull
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.xtext.naming.QualifiedName
-import tech.tablesaw.api.Table
+import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.io.readCSV
+import org.jetbrains.kotlinx.dataframe.typeClass
 
 fun inferInitialSchema(context: EObject, name: String, path: String): SdsSchema? {
-    try {
-        var colList: List<SdsColumn> = emptyList()
-
-        val table = Table.read().csv(path)
-
-        for (row in table.structure()) {
-            val colName = row.getString(1)
-            val colType = row.getString(2)
-            val colQualifiedName: QualifiedName = when (colType) {
-                "DOUBLE" -> StdlibClasses.Float
-                "STRING" -> StdlibClasses.String
-                "INTEGER" -> StdlibClasses.Int
-                "BOOLEAN" -> StdlibClasses.Boolean
-                else -> StdlibClasses.Any
-            }
-
-            val stdlibClass = context.getStdlibClassOrNull(colQualifiedName) ?: return null
-
-            colList += createSdsColumn(
-                createSdsString(colName),
-                createSdsNamedType(stdlibClass, isNullable = true)
-            )
+    val dataFrame = DataFrame.readCSV(path)
+    val columns = dataFrame.columns().map {
+        val colQualifiedName: QualifiedName = when (it.typeClass) {
+            Double::class -> StdlibClasses.Float
+            String::class -> StdlibClasses.String
+            Int::class -> StdlibClasses.Int
+            Boolean::class -> StdlibClasses.Boolean
+            else -> StdlibClasses.Any
         }
 
-        return createSdsSchema(name, columns = colList)
-    } catch (e: IllegalStateException) {
-        return null
+        val stdlibClass = context.getStdlibClassOrNull(colQualifiedName) ?: return null
+
+        createSdsColumn(
+            createSdsString(it.name()),
+            createSdsNamedType(stdlibClass, isNullable = true),
+        )
     }
+
+    return createSdsSchema(name, columns = columns)
 }


### PR DESCRIPTION
Closes #82.

### Summary of Changes

Use `kotlinx.dataframe` for inference rather than Tablesaw since it provides a more idiomatic Kotlin API.

