### PR TITLE
refactor!: annotation to mark API elements as experimental

### DIFF
--- a/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/constant/SdsFileExtension.kt
+++ b/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/constant/SdsFileExtension.kt
@@ -96,7 +96,6 @@ fun Resource.isTestFile() = this.hasExtension(SdsFileExtension.Test)
  * Returns whether the resource represents a file with the given extension.
  */
 private fun Resource.hasExtension(fileExtension: SdsFileExtension): Boolean {
-
     // The original file path is normally lost for dynamic tests, so it's attached as an EMF adapter
     this.eAdapters().filterIsInstance<OriginalFilePath>().firstOrNull()?.let {
         return it.path.endsWith(".$fileExtension")

--- a/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/constant/SdsFileExtension.kt
+++ b/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/constant/SdsFileExtension.kt
@@ -1,6 +1,7 @@
 package com.larsreimann.safeds.constant
 
 import com.larsreimann.safeds.emf.OriginalFilePath
+import com.larsreimann.safeds.utils.ExperimentalSdsApi
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.resource.Resource
 
@@ -24,6 +25,7 @@ enum class SdsFileExtension(val extension: String) {
      * @see isInSchemaFile
      * @see isSchemaFile
      */
+    @ExperimentalSdsApi
     Schema("sdsschema"),
 
     /**
@@ -56,6 +58,7 @@ fun EObject.isInFlowFile() = this.eResource().isFlowFile()
 /**
  * Returns whether the object is contained in schema file.
  */
+@ExperimentalSdsApi
 fun EObject.isInSchemaFile() = this.eResource().isSchemaFile()
 
 /**
@@ -76,6 +79,7 @@ fun Resource.isFlowFile() = this.hasExtension(SdsFileExtension.Flow)
 /**
  * Returns whether the resource represents a schema file.
  */
+@ExperimentalSdsApi
 fun Resource.isSchemaFile() = this.hasExtension(SdsFileExtension.Schema)
 
 /**

--- a/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/constant/SdsKind.kt
+++ b/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/constant/SdsKind.kt
@@ -1,10 +1,12 @@
 package com.larsreimann.safeds.constant
 
 import com.larsreimann.safeds.safeDS.SdsTypeParameter
+import com.larsreimann.safeds.utils.ExperimentalSdsApi
 
 /**
- * The possible Kinds for an [SdsTypeParameter].
+ * The possible kinds for an [SdsTypeParameter].
  */
+@ExperimentalSdsApi
 enum class SdsKind(val kind: String?) {
     NoKind(null),
     SchemaKind("\$SchemaType"),
@@ -25,6 +27,7 @@ enum class SdsKind(val kind: String?) {
  *
  * @throws IllegalArgumentException If the kind is unknown.
  */
+@ExperimentalSdsApi
 fun SdsTypeParameter.kind(): SdsKind {
     return SdsKind.values().firstOrNull { it.kind == this.kind }
         ?: throw IllegalArgumentException("Unknown kind '$kind'.")

--- a/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/constant/SdsProtocolQuantifiedTermQuantifier.kt
+++ b/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/constant/SdsProtocolQuantifiedTermQuantifier.kt
@@ -1,10 +1,12 @@
 package com.larsreimann.safeds.constant
 
 import com.larsreimann.safeds.safeDS.SdsProtocolQuantifiedTerm
+import com.larsreimann.safeds.utils.ExperimentalSdsApi
 
 /**
  * The possible quantifiers for an [SdsProtocolQuantifiedTerm].
  */
+@ExperimentalSdsApi
 enum class SdsProtocolQuantifiedTermQuantifier(val quantifier: String) {
     ZeroOrOne("?"),
     ZeroOrMore("*"),
@@ -20,6 +22,7 @@ enum class SdsProtocolQuantifiedTermQuantifier(val quantifier: String) {
  *
  * @throws IllegalArgumentException If the quantifier is unknown.
  */
+@ExperimentalSdsApi
 fun SdsProtocolQuantifiedTerm.quantifier(): SdsProtocolQuantifiedTermQuantifier {
     return SdsProtocolQuantifiedTermQuantifier.values().firstOrNull { it.quantifier == this.quantifier }
         ?: throw IllegalArgumentException("Unknown quantified term quantifier '$quantifier'.")

--- a/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/constant/SdsProtocolTokenClassValue.kt
+++ b/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/constant/SdsProtocolTokenClassValue.kt
@@ -1,10 +1,12 @@
 package com.larsreimann.safeds.constant
 
 import com.larsreimann.safeds.safeDS.SdsProtocolTokenClass
+import com.larsreimann.safeds.utils.ExperimentalSdsApi
 
 /**
  * The possible values for an [SdsProtocolTokenClass].
  */
+@ExperimentalSdsApi
 enum class SdsProtocolTokenClassValue(val value: String) {
 
     /**
@@ -32,6 +34,7 @@ enum class SdsProtocolTokenClassValue(val value: String) {
  *
  * @throws IllegalArgumentException If the value is unknown.
  */
+@ExperimentalSdsApi
 fun SdsProtocolTokenClass.value(): SdsProtocolTokenClassValue {
     return SdsProtocolTokenClassValue.values().firstOrNull { it.value == this.value }
         ?: throw IllegalArgumentException("Unknown token class value value '$value'.")

--- a/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/constant/SdsTypeParameterConstraintOperator.kt
+++ b/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/constant/SdsTypeParameterConstraintOperator.kt
@@ -1,10 +1,12 @@
 package com.larsreimann.safeds.constant
 
 import com.larsreimann.safeds.safeDS.SdsTypeParameterConstraintGoal
+import com.larsreimann.safeds.utils.ExperimentalSdsApi
 
 /**
  * The possible operators for an [SdsTypeParameterConstraintGoal].
  */
+@ExperimentalSdsApi
 enum class SdsTypeParameterConstraintOperator(val operator: String) {
 
     /**
@@ -29,6 +31,7 @@ enum class SdsTypeParameterConstraintOperator(val operator: String) {
  *
  * @throws IllegalArgumentException If the operator is unknown.
  */
+@ExperimentalSdsApi
 fun SdsTypeParameterConstraintGoal.operator(): SdsTypeParameterConstraintOperator {
     return SdsTypeParameterConstraintOperator.values().firstOrNull { it.operator == this.operator }
         ?: throw IllegalArgumentException("Unknown type parameter constraint operator '$operator'.")

--- a/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/constant/SdsVariance.kt
+++ b/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/constant/SdsVariance.kt
@@ -2,10 +2,12 @@ package com.larsreimann.safeds.constant
 
 import com.larsreimann.safeds.safeDS.SdsTypeParameter
 import com.larsreimann.safeds.safeDS.SdsTypeProjection
+import com.larsreimann.safeds.utils.ExperimentalSdsApi
 
 /**
  * The possible variances for an [SdsTypeParameter] or [SdsTypeProjection].
  */
+@ExperimentalSdsApi
 enum class SdsVariance(val variance: String?) {
 
     /**
@@ -52,6 +54,7 @@ enum class SdsVariance(val variance: String?) {
  *
  * @throws IllegalArgumentException If the variance is unknown.
  */
+@ExperimentalSdsApi
 fun SdsTypeParameter.variance(): SdsVariance {
     return SdsVariance.values().firstOrNull { it.variance == this.variance }
         ?: throw IllegalArgumentException("Unknown variance '$variance'.")
@@ -62,6 +65,7 @@ fun SdsTypeParameter.variance(): SdsVariance {
  *
  * @throws IllegalArgumentException If the variance is unknown.
  */
+@ExperimentalSdsApi
 fun SdsTypeProjection.variance(): SdsVariance {
     return SdsVariance.values().firstOrNull { it.variance == this.variance }
         ?: throw IllegalArgumentException("Unknown variance '$variance'.")

--- a/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/emf/Creators.kt
+++ b/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/emf/Creators.kt
@@ -106,6 +106,7 @@ import com.larsreimann.safeds.safeDS.SdsUnionType
 import com.larsreimann.safeds.safeDS.SdsWildcard
 import com.larsreimann.safeds.safeDS.SdsWorkflow
 import com.larsreimann.safeds.safeDS.SdsYield
+import com.larsreimann.safeds.utils.ExperimentalSdsApi
 import com.larsreimann.safeds.utils.nullIfEmptyElse
 import org.eclipse.emf.common.util.URI
 import org.eclipse.emf.ecore.resource.Resource
@@ -544,6 +545,7 @@ private fun SdsCompilationUnit.addMember(member: SdsAbstractCompilationUnitMembe
 /**
  * Returns a new object of class [SdsConstraint].
  */
+@ExperimentalSdsApi
 fun createSdsConstraint(goals: List<SdsAbstractConstraintGoal>): SdsConstraint {
     return factory.createSdsConstraint().apply {
         this.constraintList = createSdsGoalList(goals)
@@ -553,13 +555,14 @@ fun createSdsConstraint(goals: List<SdsAbstractConstraintGoal>): SdsConstraint {
 /**
  * Returns a new object of class [SdsColumn].
  */
+@ExperimentalSdsApi
 fun createSdsColumn(
-    columnName: SdsString,
-    columnType: SdsAbstractType
+    name: String,
+    type: SdsAbstractType
 ): SdsColumn {
     return factory.createSdsColumn().apply {
-        this.columnName = columnName
-        this.columnType = columnType
+        this.columnName = createSdsString(name)
+        this.columnType = type
     }
 }
 
@@ -1008,7 +1011,6 @@ fun createSdsParameterList(parameters: List<SdsParameter>): SdsParameterList {
  * Returns a new object of class [SdsLambdaParameterList]. These have to be used as parameter lists of an
  * [SdsAbstractLambda]
  */
-@Suppress("FunctionName")
 fun createSdsLambdaParameterList(parameters: List<SdsParameter>): SdsLambdaParameterList {
     return factory.createSdsLambdaParameterList().apply {
         this.parameters += parameters
@@ -1124,6 +1126,7 @@ fun createSdsPrefixOperation(operator: SdsPrefixOperationOperator, operand: SdsA
 /**
  * Returns a new object of class [SdsProtocol].
  */
+@ExperimentalSdsApi
 fun createSdsProtocol(
     subterms: List<SdsProtocolSubterm> = emptyList(),
     term: SdsAbstractProtocolTerm? = null,
@@ -1140,6 +1143,7 @@ fun createSdsProtocol(
 /**
  * Adds a new object of class [SdsProtocol] to the receiver.
  */
+@ExperimentalSdsApi
 fun SdsClass.sdsProtocol(
     subterms: List<SdsProtocolSubterm> = emptyList(),
     term: SdsAbstractProtocolTerm? = null,
@@ -1151,6 +1155,7 @@ fun SdsClass.sdsProtocol(
 /**
  * Adds a new subterm to the receiver.
  */
+@ExperimentalSdsApi
 private fun SdsProtocol.addSubterm(subterm: SdsProtocolSubterm) {
     if (this.body == null) {
         this.body = factory.createSdsProtocolBody()
@@ -1166,6 +1171,7 @@ private fun SdsProtocol.addSubterm(subterm: SdsProtocolSubterm) {
 /**
  * Returns a new object of class [SdsProtocolAlternative].
  */
+@ExperimentalSdsApi
 fun createSdsProtocolAlternative(terms: List<SdsAbstractProtocolTerm>): SdsProtocolAlternative {
     if (terms.size < 2) {
         throw IllegalArgumentException("Must have at least two terms.")
@@ -1179,6 +1185,7 @@ fun createSdsProtocolAlternative(terms: List<SdsAbstractProtocolTerm>): SdsProto
 /**
  * Returns a new object of class [SdsProtocolComplement].
  */
+@ExperimentalSdsApi
 fun createSdsProtocolComplement(
     universe: SdsProtocolTokenClass? = null,
     references: List<SdsProtocolReference> = emptyList()
@@ -1192,6 +1199,7 @@ fun createSdsProtocolComplement(
 /**
  * Returns a new object of class [SdsProtocolParenthesizedTerm].
  */
+@ExperimentalSdsApi
 fun createSdsProtocolParenthesizedTerm(term: SdsAbstractProtocolTerm): SdsProtocolParenthesizedTerm {
     return factory.createSdsProtocolParenthesizedTerm().apply {
         this.term = term
@@ -1201,6 +1209,7 @@ fun createSdsProtocolParenthesizedTerm(term: SdsAbstractProtocolTerm): SdsProtoc
 /**
  * Returns a new object of class [SdsProtocolQuantifiedTerm].
  */
+@ExperimentalSdsApi
 fun createSdsProtocolQuantifiedTerm(
     term: SdsAbstractProtocolTerm,
     quantifier: SdsProtocolQuantifiedTermQuantifier
@@ -1214,6 +1223,7 @@ fun createSdsProtocolQuantifiedTerm(
 /**
  * Returns a new object of class [SdsProtocolReference].
  */
+@ExperimentalSdsApi
 fun createSdsProtocolReference(token: SdsAbstractProtocolToken): SdsProtocolReference {
     return factory.createSdsProtocolReference().apply {
         this.token = token
@@ -1223,6 +1233,7 @@ fun createSdsProtocolReference(token: SdsAbstractProtocolToken): SdsProtocolRefe
 /**
  * Returns a new object of class [SdsProtocolReferenceList].
  */
+@ExperimentalSdsApi
 fun createSdsProtocolReferenceList(references: List<SdsProtocolReference>): SdsProtocolReferenceList {
     return factory.createSdsProtocolReferenceList().apply {
         this.references += references
@@ -1234,6 +1245,7 @@ fun createSdsProtocolReferenceList(references: List<SdsProtocolReference>): SdsP
  *
  * @throws IllegalArgumentException If `terms.size < 2`.
  */
+@ExperimentalSdsApi
 fun createSdsProtocolSequence(terms: List<SdsAbstractProtocolTerm>): SdsProtocolSequence {
     if (terms.size < 2) {
         throw IllegalArgumentException("Must have at least two terms.")
@@ -1247,6 +1259,7 @@ fun createSdsProtocolSequence(terms: List<SdsAbstractProtocolTerm>): SdsProtocol
 /**
  * Returns a new object of class [SdsProtocolSubterm].
  */
+@ExperimentalSdsApi
 fun createSdsProtocolSubterm(name: String, term: SdsAbstractProtocolTerm): SdsProtocolSubterm {
     return factory.createSdsProtocolSubterm().apply {
         this.name = name
@@ -1257,6 +1270,7 @@ fun createSdsProtocolSubterm(name: String, term: SdsAbstractProtocolTerm): SdsPr
 /**
  * Returns a new object of class [SdsProtocolSubterm].
  */
+@ExperimentalSdsApi
 fun SdsProtocol.sdsProtocolSubterm(name: String, term: SdsAbstractProtocolTerm) {
     this.addSubterm(createSdsProtocolSubterm(name, term))
 }
@@ -1264,6 +1278,7 @@ fun SdsProtocol.sdsProtocolSubterm(name: String, term: SdsAbstractProtocolTerm) 
 /**
  * Returns a new object of class [SdsProtocolTokenClass].
  */
+@ExperimentalSdsApi
 fun createSdsProtocolTokenClass(value: SdsProtocolTokenClassValue): SdsProtocolTokenClass {
     return factory.createSdsProtocolTokenClass().apply {
         this.value = value.value
@@ -1313,6 +1328,7 @@ fun createSdsStarProjection(): SdsStarProjection {
 /**
  * Returns a new object of class [SdsSchema].
  */
+@ExperimentalSdsApi
 fun createSdsSchema(
     name: String,
     annotationCalls: List<SdsAnnotationCall> = emptyList(),
@@ -1328,6 +1344,7 @@ fun createSdsSchema(
 /**
  * Adds a new object of class [SdsSchema] to the receiver.
  */
+@ExperimentalSdsApi
 fun SdsCompilationUnit.sdsSchema(
     name: String,
     annotationCalls: List<SdsAnnotationCall> = emptyList(),
@@ -1345,6 +1362,7 @@ fun SdsCompilationUnit.sdsSchema(
 /**
  * Adds a new column to the receiver.
  */
+@ExperimentalSdsApi
 private fun SdsSchema.addColumn(column: SdsColumn) {
     if (this.columnList == null) {
         this.columnList = factory.createSdsColumnList()
@@ -1491,6 +1509,7 @@ fun createSdsTypeArgument(
 /**
  * Returns a new object of class [SdsTypeArgument] that points to a type parameter with the given name.
  */
+@OptIn(ExperimentalSdsApi::class)
 fun createSdsTypeArgument(
     value: SdsAbstractTypeArgumentValue,
     typeParameterName: String
@@ -1513,6 +1532,7 @@ fun createSdsTypeArgumentList(typeArguments: List<SdsTypeArgument>): SdsTypeArgu
 /**
  * Returns a new object of class [SdsTypeParameter].
  */
+@ExperimentalSdsApi
 fun createSdsTypeParameter(
     name: String,
     annotationCalls: List<SdsAnnotationCall> = emptyList(),
@@ -1539,6 +1559,7 @@ fun createSdsTypeParameterList(typeParameters: List<SdsTypeParameter>): SdsTypeP
 /**
  * Returns a new object of class [SdsTypeParameterConstraintGoal].
  */
+@ExperimentalSdsApi
 fun createSdsTypeParameterConstraintGoal(
     leftOperand: SdsTypeParameter,
     operator: SdsTypeParameterConstraintOperator,
@@ -1554,6 +1575,7 @@ fun createSdsTypeParameterConstraintGoal(
 /**
  * Returns a new object of class [SdsTypeParameterConstraintGoal] that points to a type parameter with the given name.
  */
+@ExperimentalSdsApi
 fun createSdsTypeParameterConstraintGoal(
     leftOperandName: String,
     operator: SdsTypeParameterConstraintOperator,
@@ -1569,6 +1591,7 @@ fun createSdsTypeParameterConstraintGoal(
 /**
  * Returns a new object of class [SdsTypeProjection].
  */
+@ExperimentalSdsApi
 fun createSdsTypeProjection(type: SdsAbstractType, variance: SdsVariance = SdsVariance.Invariant): SdsTypeProjection {
     return factory.createSdsTypeProjection().apply {
         this.type = type

--- a/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/emf/Creators.kt
+++ b/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/emf/Creators.kt
@@ -124,7 +124,7 @@ private val factory = SafeDSFactory.eINSTANCE
 fun createSdsDummyResource(
     fileName: String,
     fileExtension: SdsFileExtension,
-    compilationUnit: SdsCompilationUnit
+    compilationUnit: SdsCompilationUnit,
 ): Resource {
     val uri = URI.createURI("dummy:/$fileName.${fileExtension.extension}")
     return XtextResource(uri).apply {
@@ -142,13 +142,13 @@ fun createSdsDummyResource(
     fileName: String,
     fileExtension: SdsFileExtension,
     packageName: String,
-    init: SdsCompilationUnit.() -> Unit = {}
+    init: SdsCompilationUnit.() -> Unit = {},
 ): Resource {
     val uri = URI.createURI("dummy:/$fileName.${fileExtension.extension}")
     return XtextResource(uri).apply {
         this.contents += createSdsCompilationUnit(
             packageName = packageName,
-            init = init
+            init = init,
         )
     }
 }
@@ -159,7 +159,7 @@ fun createSdsDummyResource(
 fun createSdsAnnotation(
     name: String,
     annotationCalls: List<SdsAnnotationCall> = emptyList(),
-    parameters: List<SdsParameter> = emptyList()
+    parameters: List<SdsParameter> = emptyList(),
 ): SdsAnnotation {
     return factory.createSdsAnnotation().apply {
         this.name = name
@@ -174,7 +174,7 @@ fun createSdsAnnotation(
 fun SdsCompilationUnit.sdsAnnotation(
     name: String,
     annotationCalls: List<SdsAnnotationCall> = emptyList(),
-    parameters: List<SdsParameter> = emptyList()
+    parameters: List<SdsParameter> = emptyList(),
 ) {
     this.addMember(createSdsAnnotation(name, annotationCalls, parameters))
 }
@@ -184,7 +184,7 @@ fun SdsCompilationUnit.sdsAnnotation(
  */
 fun createSdsAnnotationCall(
     annotation: SdsAnnotation,
-    arguments: List<SdsArgument> = emptyList()
+    arguments: List<SdsArgument> = emptyList(),
 ): SdsAnnotationCall {
     return factory.createSdsAnnotationCall().apply {
         this.annotation = annotation
@@ -197,11 +197,11 @@ fun createSdsAnnotationCall(
  */
 fun createSdsAnnotationCall(
     annotationName: String,
-    arguments: List<SdsArgument> = emptyList()
+    arguments: List<SdsArgument> = emptyList(),
 ): SdsAnnotationCall {
     return createSdsAnnotationCall(
         createSdsAnnotation(annotationName),
-        arguments
+        arguments,
     )
 }
 
@@ -230,7 +230,7 @@ fun createSdsArgument(value: SdsAbstractExpression, parameter: SdsParameter? = n
 fun createSdsArgument(value: SdsAbstractExpression, parameterName: String): SdsArgument {
     return createSdsArgument(
         value,
-        createSdsParameter(parameterName)
+        createSdsParameter(parameterName),
     )
 }
 
@@ -315,7 +315,7 @@ fun createSdsAttribute(
     name: String,
     annotationCalls: List<SdsAnnotationCall> = emptyList(),
     isStatic: Boolean = false,
-    type: SdsAbstractType? = null
+    type: SdsAbstractType? = null,
 ): SdsAttribute {
     return factory.createSdsAttribute().apply {
         this.name = name
@@ -332,7 +332,7 @@ fun SdsClass.sdsAttribute(
     name: String,
     annotationCalls: List<SdsAnnotationCall> = emptyList(),
     isStatic: Boolean = false,
-    type: SdsAbstractType? = null
+    type: SdsAbstractType? = null,
 ) {
     this.addMember(createSdsAttribute(name, annotationCalls, isStatic, type))
 }
@@ -342,7 +342,7 @@ fun SdsClass.sdsAttribute(
  */
 fun createSdsBlock(
     statements: List<SdsAbstractStatement> = emptyList(),
-    init: SdsBlock.() -> Unit = {}
+    init: SdsBlock.() -> Unit = {},
 ): SdsBlock {
     return factory.createSdsBlock().apply {
         this.statements += statements
@@ -356,7 +356,7 @@ fun createSdsBlock(
 fun createSdsBlockLambda(
     parameters: List<SdsParameter> = emptyList(),
     statements: List<SdsAbstractStatement> = emptyList(),
-    init: SdsBlockLambda.() -> Unit = {}
+    init: SdsBlockLambda.() -> Unit = {},
 ): SdsBlockLambda {
     return factory.createSdsBlockLambda().apply {
         this.parameterList = createSdsLambdaParameterList(parameters)
@@ -401,7 +401,7 @@ fun createSdsBoolean(value: Boolean): SdsBoolean {
 fun createSdsCall(
     receiver: SdsAbstractExpression,
     typeArguments: List<SdsTypeArgument> = emptyList(),
-    arguments: List<SdsArgument> = emptyList()
+    arguments: List<SdsArgument> = emptyList(),
 ): SdsCall {
     return factory.createSdsCall().apply {
         this.receiver = receiver
@@ -432,7 +432,7 @@ fun createSdsClass(
     constraint: SdsConstraint? = null,
     protocol: SdsProtocol? = null,
     members: List<SdsAbstractClassMember> = emptyList(),
-    init: SdsClass.() -> Unit = {}
+    init: SdsClass.() -> Unit = {},
 ): SdsClass {
     return factory.createSdsClass().apply {
         this.name = name
@@ -459,7 +459,7 @@ fun SdsClass.sdsClass(
     constraint: SdsConstraint? = null,
     protocol: SdsProtocol? = null,
     members: List<SdsAbstractClassMember> = emptyList(),
-    init: SdsClass.() -> Unit = {}
+    init: SdsClass.() -> Unit = {},
 ) {
     this.addMember(
         createSdsClass(
@@ -471,8 +471,8 @@ fun SdsClass.sdsClass(
             constraint,
             protocol,
             members,
-            init
-        )
+            init,
+        ),
     )
 }
 
@@ -488,7 +488,7 @@ fun SdsCompilationUnit.sdsClass(
     constraint: SdsConstraint? = null,
     protocol: SdsProtocol? = null,
     members: List<SdsAbstractClassMember> = emptyList(),
-    init: SdsClass.() -> Unit = {}
+    init: SdsClass.() -> Unit = {},
 ) {
     this.addMember(
         createSdsClass(
@@ -500,8 +500,8 @@ fun SdsCompilationUnit.sdsClass(
             constraint,
             protocol,
             members,
-            init
-        )
+            init,
+        ),
     )
 }
 
@@ -524,7 +524,7 @@ fun createSdsCompilationUnit(
     annotationCalls: List<SdsAnnotationCall> = emptyList(),
     imports: List<SdsImport> = emptyList(),
     members: List<SdsAbstractCompilationUnitMember> = emptyList(),
-    init: SdsCompilationUnit.() -> Unit = {}
+    init: SdsCompilationUnit.() -> Unit = {},
 ): SdsCompilationUnit {
     return factory.createSdsCompilationUnit().apply {
         this.name = packageName
@@ -558,7 +558,7 @@ fun createSdsConstraint(goals: List<SdsAbstractConstraintGoal>): SdsConstraint {
 @ExperimentalSdsApi
 fun createSdsColumn(
     name: String,
-    type: SdsAbstractType
+    type: SdsAbstractType,
 ): SdsColumn {
     return factory.createSdsColumn().apply {
         this.columnName = createSdsString(name)
@@ -573,7 +573,7 @@ fun createSdsEnum(
     name: String,
     annotationCalls: List<SdsAnnotationCall> = emptyList(),
     variants: List<SdsEnumVariant> = emptyList(),
-    init: SdsEnum.() -> Unit = {}
+    init: SdsEnum.() -> Unit = {},
 ): SdsEnum {
     return factory.createSdsEnum().apply {
         this.name = name
@@ -590,7 +590,7 @@ fun SdsClass.sdsEnum(
     name: String,
     annotationCalls: List<SdsAnnotationCall> = emptyList(),
     variants: List<SdsEnumVariant> = emptyList(),
-    init: SdsEnum.() -> Unit = {}
+    init: SdsEnum.() -> Unit = {},
 ) {
     this.addMember(createSdsEnum(name, annotationCalls, variants, init))
 }
@@ -602,7 +602,7 @@ fun SdsCompilationUnit.sdsEnum(
     name: String,
     annotationCalls: List<SdsAnnotationCall> = emptyList(),
     variants: List<SdsEnumVariant> = emptyList(),
-    init: SdsEnum.() -> Unit = {}
+    init: SdsEnum.() -> Unit = {},
 ) {
     this.addMember(createSdsEnum(name, annotationCalls, variants, init))
 }
@@ -645,7 +645,7 @@ fun SdsEnum.sdsEnumVariant(
     annotationCalls: List<SdsAnnotationCall> = emptyList(),
     typeParameters: List<SdsTypeParameter> = emptyList(),
     parameters: List<SdsParameter> = emptyList(),
-    constraint: SdsConstraint? = null
+    constraint: SdsConstraint? = null,
 ) {
     this.addVariant(createSdsEnumVariant(name, annotationCalls, typeParameters, parameters, constraint))
 }
@@ -671,7 +671,7 @@ fun SdsPredicate.sdsExpressionGoal(expression: SdsAbstractGoalExpression) {
  */
 fun createSdsExpressionLambda(
     parameters: List<SdsParameter> = emptyList(),
-    result: SdsAbstractExpression
+    result: SdsAbstractExpression,
 ): SdsExpressionLambda {
     return factory.createSdsExpressionLambda().apply {
         this.parameterList = createSdsLambdaParameterList(parameters)
@@ -734,7 +734,7 @@ fun createSdsFunction(
     typeParameters: List<SdsTypeParameter> = emptyList(),
     parameters: List<SdsParameter> = emptyList(),
     results: List<SdsResult> = emptyList(),
-    constraint: SdsConstraint? = null
+    constraint: SdsConstraint? = null,
 ): SdsFunction {
     return factory.createSdsFunction().apply {
         this.name = name
@@ -768,7 +768,7 @@ fun SdsClass.sdsFunction(
     typeParameters: List<SdsTypeParameter> = emptyList(),
     parameters: List<SdsParameter> = emptyList(),
     results: List<SdsResult> = emptyList(),
-    constraint: SdsConstraint? = null
+    constraint: SdsConstraint? = null,
 ) {
     this.addMember(
         createSdsFunction(
@@ -778,8 +778,8 @@ fun SdsClass.sdsFunction(
             typeParameters,
             parameters,
             results,
-            constraint
-        )
+            constraint,
+        ),
     )
 }
 
@@ -793,7 +793,7 @@ fun SdsCompilationUnit.sdsFunction(
     typeParameters: List<SdsTypeParameter> = emptyList(),
     parameters: List<SdsParameter> = emptyList(),
     results: List<SdsResult> = emptyList(),
-    constraint: SdsConstraint? = null
+    constraint: SdsConstraint? = null,
 ) {
     this.addMember(
         createSdsFunction(
@@ -803,8 +803,8 @@ fun SdsCompilationUnit.sdsFunction(
             typeParameters,
             parameters,
             results,
-            constraint
-        )
+            constraint,
+        ),
     )
 }
 
@@ -824,7 +824,7 @@ fun createSdsGoalArgument(value: SdsAbstractGoalExpression, parameter: SdsParame
 fun createSdsGoalArgument(value: SdsAbstractGoalExpression, parameterName: String): SdsGoalArgument {
     return createSdsGoalArgument(
         value,
-        createSdsParameter(parameterName)
+        createSdsParameter(parameterName),
     )
 }
 
@@ -842,7 +842,7 @@ fun createSdsGoalArgumentList(arguments: List<SdsGoalArgument>): SdsGoalArgument
  */
 fun createSdsGoalCall(
     receiver: SdsAbstractGoalExpression,
-    arguments: List<SdsGoalArgument>
+    arguments: List<SdsGoalArgument>,
 ): SdsGoalCall {
     return factory.createSdsGoalCall().apply {
         this.receiver = receiver
@@ -895,7 +895,7 @@ private fun createSdsImportAlias(name: String?): SdsImportAlias? {
  * Returns a new object of class [SdsIndexedAccess].
  */
 fun createSdsIndexedAccess(
-    index: SdsAbstractExpression
+    index: SdsAbstractExpression,
 ): SdsIndexedAccess {
     return factory.createSdsIndexedAccess().apply {
         this.index = index
@@ -908,7 +908,7 @@ fun createSdsIndexedAccess(
 fun createSdsInfixOperation(
     leftOperand: SdsAbstractExpression,
     operator: SdsInfixOperationOperator,
-    rightOperand: SdsAbstractExpression
+    rightOperand: SdsAbstractExpression,
 ): SdsInfixOperation {
     return factory.createSdsInfixOperation().apply {
         this.leftOperand = leftOperand
@@ -938,7 +938,7 @@ fun createSdsInt(value: Int): SdsAbstractExpression {
 fun createSdsMemberAccess(
     receiver: SdsAbstractExpression,
     member: SdsReference,
-    isNullSafe: Boolean = false
+    isNullSafe: Boolean = false,
 ): SdsMemberAccess {
     return factory.createSdsMemberAccess().apply {
         this.receiver = receiver
@@ -963,7 +963,7 @@ fun createSdsMemberType(receiver: SdsAbstractType, member: SdsNamedType): SdsMem
 fun createSdsNamedType(
     declaration: SdsAbstractNamedTypeDeclaration,
     typeArguments: List<SdsTypeArgument> = emptyList(),
-    isNullable: Boolean = false
+    isNullable: Boolean = false,
 ): SdsNamedType {
     return factory.createSdsNamedType().apply {
         this.declaration = declaration
@@ -987,7 +987,7 @@ fun createSdsParameter(
     annotationCalls: List<SdsAnnotationCall> = emptyList(),
     isVariadic: Boolean = false,
     type: SdsAbstractType? = null,
-    defaultValue: SdsAbstractExpression? = null
+    defaultValue: SdsAbstractExpression? = null,
 ): SdsParameter {
     return factory.createSdsParameter().apply {
         this.name = name
@@ -1097,8 +1097,8 @@ fun SdsCompilationUnit.sdsPredicate(
             annotationCalls,
             parameters,
             results,
-            goals
-        )
+            goals,
+        ),
     )
 }
 
@@ -1130,7 +1130,7 @@ fun createSdsPrefixOperation(operator: SdsPrefixOperationOperator, operand: SdsA
 fun createSdsProtocol(
     subterms: List<SdsProtocolSubterm> = emptyList(),
     term: SdsAbstractProtocolTerm? = null,
-    init: SdsProtocol.() -> Unit = {}
+    init: SdsProtocol.() -> Unit = {},
 ): SdsProtocol {
     return factory.createSdsProtocol().apply {
         this.body = factory.createSdsProtocolBody()
@@ -1147,7 +1147,7 @@ fun createSdsProtocol(
 fun SdsClass.sdsProtocol(
     subterms: List<SdsProtocolSubterm> = emptyList(),
     term: SdsAbstractProtocolTerm? = null,
-    init: SdsProtocol.() -> Unit = {}
+    init: SdsProtocol.() -> Unit = {},
 ) {
     this.addMember(createSdsProtocol(subterms, term, init))
 }
@@ -1188,7 +1188,7 @@ fun createSdsProtocolAlternative(terms: List<SdsAbstractProtocolTerm>): SdsProto
 @ExperimentalSdsApi
 fun createSdsProtocolComplement(
     universe: SdsProtocolTokenClass? = null,
-    references: List<SdsProtocolReference> = emptyList()
+    references: List<SdsProtocolReference> = emptyList(),
 ): SdsProtocolComplement {
     return factory.createSdsProtocolComplement().apply {
         this.universe = universe
@@ -1212,7 +1212,7 @@ fun createSdsProtocolParenthesizedTerm(term: SdsAbstractProtocolTerm): SdsProtoc
 @ExperimentalSdsApi
 fun createSdsProtocolQuantifiedTerm(
     term: SdsAbstractProtocolTerm,
-    quantifier: SdsProtocolQuantifiedTermQuantifier
+    quantifier: SdsProtocolQuantifiedTermQuantifier,
 ): SdsProtocolQuantifiedTerm {
     return factory.createSdsProtocolQuantifiedTerm().apply {
         this.term = term
@@ -1300,7 +1300,7 @@ fun createSdsReference(declaration: SdsAbstractDeclaration): SdsReference {
 fun createSdsResult(
     name: String,
     annotationCalls: List<SdsAnnotationCall> = emptyList(),
-    type: SdsAbstractType? = null
+    type: SdsAbstractType? = null,
 ): SdsResult {
     return factory.createSdsResult().apply {
         this.name = name
@@ -1332,7 +1332,7 @@ fun createSdsStarProjection(): SdsStarProjection {
 fun createSdsSchema(
     name: String,
     annotationCalls: List<SdsAnnotationCall> = emptyList(),
-    columns: List<SdsColumn> = emptyList()
+    columns: List<SdsColumn> = emptyList(),
 ): SdsSchema {
     return factory.createSdsSchema().apply {
         this.name = name
@@ -1348,14 +1348,14 @@ fun createSdsSchema(
 fun SdsCompilationUnit.sdsSchema(
     name: String,
     annotationCalls: List<SdsAnnotationCall> = emptyList(),
-    columns: List<SdsColumn> = emptyList()
+    columns: List<SdsColumn> = emptyList(),
 ) {
     this.addMember(
         createSdsSchema(
             name,
             annotationCalls,
-            columns
-        )
+            columns,
+        ),
     )
 }
 
@@ -1380,7 +1380,7 @@ fun createSdsStep(
     parameters: List<SdsParameter> = emptyList(),
     results: List<SdsResult> = emptyList(),
     statements: List<SdsAbstractStatement> = emptyList(),
-    init: SdsStep.() -> Unit = {}
+    init: SdsStep.() -> Unit = {},
 ): SdsStep {
     return factory.createSdsStep().apply {
         this.name = name
@@ -1404,7 +1404,7 @@ fun SdsCompilationUnit.sdsStep(
     parameters: List<SdsParameter> = emptyList(),
     results: List<SdsResult> = emptyList(),
     statements: List<SdsAbstractStatement> = emptyList(),
-    init: SdsStep.() -> Unit = {}
+    init: SdsStep.() -> Unit = {},
 ) {
     this.addMember(
         createSdsStep(
@@ -1414,8 +1414,8 @@ fun SdsCompilationUnit.sdsStep(
             parameters,
             results,
             statements,
-            init
-        )
+            init,
+        ),
     )
 }
 
@@ -1449,9 +1449,8 @@ fun createSdsString(value: String): SdsString {
  */
 fun createSdsTemplateString(
     stringParts: List<String>,
-    templateExpressions: List<SdsAbstractExpression>
+    templateExpressions: List<SdsAbstractExpression>,
 ): SdsTemplateString {
-
     // One of the first two checks is sufficient but this allows better error messages.
     if (stringParts.size < 2) {
         throw IllegalArgumentException("Must have at least two string parts.")
@@ -1498,7 +1497,7 @@ fun createSdsTemplateString(
  */
 fun createSdsTypeArgument(
     value: SdsAbstractTypeArgumentValue,
-    typeParameter: SdsTypeParameter? = null
+    typeParameter: SdsTypeParameter? = null,
 ): SdsTypeArgument {
     return factory.createSdsTypeArgument().apply {
         this.value = value
@@ -1512,11 +1511,11 @@ fun createSdsTypeArgument(
 @OptIn(ExperimentalSdsApi::class)
 fun createSdsTypeArgument(
     value: SdsAbstractTypeArgumentValue,
-    typeParameterName: String
+    typeParameterName: String,
 ): SdsTypeArgument {
     return createSdsTypeArgument(
         value,
-        createSdsTypeParameter(typeParameterName)
+        createSdsTypeParameter(typeParameterName),
     )
 }
 
@@ -1537,7 +1536,7 @@ fun createSdsTypeParameter(
     name: String,
     annotationCalls: List<SdsAnnotationCall> = emptyList(),
     variance: SdsVariance = SdsVariance.Invariant,
-    kind: SdsKind = SdsKind.NoKind
+    kind: SdsKind = SdsKind.NoKind,
 ): SdsTypeParameter {
     return factory.createSdsTypeParameter().apply {
         this.name = name
@@ -1563,7 +1562,7 @@ fun createSdsTypeParameterList(typeParameters: List<SdsTypeParameter>): SdsTypeP
 fun createSdsTypeParameterConstraintGoal(
     leftOperand: SdsTypeParameter,
     operator: SdsTypeParameterConstraintOperator,
-    rightOperand: SdsAbstractType
+    rightOperand: SdsAbstractType,
 ): SdsTypeParameterConstraintGoal {
     return factory.createSdsTypeParameterConstraintGoal().apply {
         this.leftOperand = leftOperand
@@ -1579,12 +1578,12 @@ fun createSdsTypeParameterConstraintGoal(
 fun createSdsTypeParameterConstraintGoal(
     leftOperandName: String,
     operator: SdsTypeParameterConstraintOperator,
-    rightOperand: SdsAbstractType
+    rightOperand: SdsAbstractType,
 ): SdsTypeParameterConstraintGoal {
     return createSdsTypeParameterConstraintGoal(
         createSdsTypeParameter(leftOperandName),
         operator,
-        rightOperand
+        rightOperand,
     )
 }
 
@@ -1628,7 +1627,7 @@ fun createSdsWorkflow(
     name: String,
     annotationCalls: List<SdsAnnotationCall> = emptyList(),
     statements: List<SdsAbstractStatement> = emptyList(),
-    init: SdsWorkflow.() -> Unit = {}
+    init: SdsWorkflow.() -> Unit = {},
 ): SdsWorkflow {
     return factory.createSdsWorkflow().apply {
         this.name = name
@@ -1646,7 +1645,7 @@ fun SdsCompilationUnit.sdsWorkflow(
     name: String,
     annotationCalls: List<SdsAnnotationCall> = emptyList(),
     statements: List<SdsAbstractStatement> = emptyList(),
-    init: SdsWorkflow.() -> Unit = {}
+    init: SdsWorkflow.() -> Unit = {},
 ) {
     this.addMember(createSdsWorkflow(name, annotationCalls, statements, init))
 }

--- a/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/emf/SimpleShortcuts.kt
+++ b/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/emf/SimpleShortcuts.kt
@@ -56,6 +56,7 @@ import com.larsreimann.safeds.safeDS.SdsTypeParameter
 import com.larsreimann.safeds.safeDS.SdsUnionType
 import com.larsreimann.safeds.safeDS.SdsWorkflow
 import com.larsreimann.safeds.safeDS.SdsYield
+import com.larsreimann.safeds.utils.ExperimentalSdsApi
 import com.larsreimann.safeds.utils.uniqueOrNull
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.resource.Resource
@@ -103,6 +104,7 @@ fun SdsAbstractDeclaration?.annotationCallsOrEmpty(): List<SdsAnnotationCall> {
 
 // SdsAnnotation -----------------------------------------------------------------------------------
 
+@ExperimentalSdsApi
 fun SdsAnnotation?.constraintsOrEmpty(): List<SdsAbstractGoal> {
     return this?.constraint?.constraintList?.goals.orEmpty()
 }
@@ -181,6 +183,7 @@ fun SdsClass?.parentTypesOrEmpty(): List<SdsAbstractType> {
     return this?.parentTypeList?.parentTypes.orEmpty()
 }
 
+@ExperimentalSdsApi
 fun SdsClass?.constraintsOrEmpty(): List<SdsAbstractConstraintGoal> {
     return this?.body?.members
         ?.filterIsInstance<SdsAbstractConstraintGoal>()
@@ -197,12 +200,14 @@ fun SdsClass?.classMembersOrEmpty(): List<SdsAbstractClassMember> {
         .orEmpty()
 }
 
+@ExperimentalSdsApi
 fun SdsClass?.protocolsOrEmpty(): List<SdsProtocol> {
     return this?.body?.members
         ?.filterIsInstance<SdsProtocol>()
         .orEmpty()
 }
 
+@ExperimentalSdsApi
 fun SdsClass.uniqueProtocolOrNull(): SdsProtocol? {
     return this.protocolsOrEmpty().uniqueOrNull()
 }
@@ -227,6 +232,7 @@ fun SdsEnumVariant?.typeParametersOrEmpty(): List<SdsTypeParameter> {
     return this?.typeParameterList?.typeParameters.orEmpty()
 }
 
+@ExperimentalSdsApi
 fun SdsEnumVariant?.constraintsOrEmpty(): List<SdsAbstractGoal> {
     return this?.constraint?.constraintList?.goals.orEmpty()
 }
@@ -241,6 +247,7 @@ fun SdsFunction?.typeParametersOrEmpty(): List<SdsTypeParameter> {
     return this?.typeParameterList?.typeParameters.orEmpty()
 }
 
+@ExperimentalSdsApi
 fun SdsFunction?.constraintsOrEmpty(): List<SdsAbstractConstraintGoal> {
     return this?.body?.statements
         ?.filterIsInstance<SdsAbstractConstraintGoal>()

--- a/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/staticAnalysis/schema/SchemaComputer.kt
+++ b/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/staticAnalysis/schema/SchemaComputer.kt
@@ -3,34 +3,40 @@ package com.larsreimann.safeds.staticAnalysis.schema
 import com.larsreimann.safeds.emf.createSdsColumn
 import com.larsreimann.safeds.emf.createSdsNamedType
 import com.larsreimann.safeds.emf.createSdsSchema
-import com.larsreimann.safeds.emf.createSdsString
 import com.larsreimann.safeds.safeDS.SdsSchema
 import com.larsreimann.safeds.stdlibAccess.StdlibClasses
 import com.larsreimann.safeds.stdlibAccess.getStdlibClassOrNull
+import com.larsreimann.safeds.utils.ExperimentalSdsApi
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.xtext.naming.QualifiedName
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.io.readCSV
 import org.jetbrains.kotlinx.dataframe.typeClass
+import java.io.IOException
 
+@OptIn(ExperimentalSdsApi::class)
 fun inferInitialSchema(context: EObject, name: String, path: String): SdsSchema? {
-    val dataFrame = DataFrame.readCSV(path)
-    val columns = dataFrame.columns().map {
-        val colQualifiedName: QualifiedName = when (it.typeClass) {
-            Double::class -> StdlibClasses.Float
-            String::class -> StdlibClasses.String
-            Int::class -> StdlibClasses.Int
-            Boolean::class -> StdlibClasses.Boolean
-            else -> StdlibClasses.Any
+    try {
+        val dataFrame = DataFrame.readCSV(path)
+        val columns = dataFrame.columns().map {
+            val colQualifiedName: QualifiedName = when (it.typeClass) {
+                Double::class -> StdlibClasses.Float
+                String::class -> StdlibClasses.String
+                Int::class -> StdlibClasses.Int
+                Boolean::class -> StdlibClasses.Boolean
+                else -> StdlibClasses.Any
+            }
+
+            val stdlibClass = context.getStdlibClassOrNull(colQualifiedName) ?: return null
+
+            createSdsColumn(
+                name = it.name(),
+                type = createSdsNamedType(stdlibClass, isNullable = true),
+            )
         }
 
-        val stdlibClass = context.getStdlibClassOrNull(colQualifiedName) ?: return null
-
-        createSdsColumn(
-            createSdsString(it.name()),
-            createSdsNamedType(stdlibClass, isNullable = true),
-        )
+        return createSdsSchema(name, columns = columns)
+    } catch (e: IOException) {
+        return null
     }
-
-    return createSdsSchema(name, columns = columns)
 }

--- a/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/staticAnalysis/schema/SchemaComputer.kt
+++ b/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/staticAnalysis/schema/SchemaComputer.kt
@@ -12,7 +12,6 @@ import org.eclipse.xtext.naming.QualifiedName
 import org.jetbrains.kotlinx.dataframe.DataFrame
 import org.jetbrains.kotlinx.dataframe.io.readCSV
 import org.jetbrains.kotlinx.dataframe.typeClass
-import java.io.IOException
 
 @OptIn(ExperimentalSdsApi::class)
 fun inferInitialSchema(context: EObject, name: String, path: String): SdsSchema? {
@@ -36,7 +35,7 @@ fun inferInitialSchema(context: EObject, name: String, path: String): SdsSchema?
         }
 
         return createSdsSchema(name, columns = columns)
-    } catch (e: IOException) {
+    } catch (e: Exception) {
         return null
     }
 }

--- a/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/utils/MarkerAnnotations.kt
+++ b/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/utils/MarkerAnnotations.kt
@@ -1,0 +1,9 @@
+package com.larsreimann.safeds.utils
+
+/**
+ * The marked API element is experimental and may be changed or removed at any time without a major version bump. Use
+ * with caution!
+ */
+@RequiresOptIn(level = RequiresOptIn.Level.ERROR)
+@Retention(AnnotationRetention.BINARY)
+annotation class ExperimentalSdsApi

--- a/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/validation/declarations/ClassChecker.kt
+++ b/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/validation/declarations/ClassChecker.kt
@@ -13,6 +13,7 @@ import com.larsreimann.safeds.staticAnalysis.classHierarchy.isSubtypeOf
 import com.larsreimann.safeds.staticAnalysis.typing.ClassType
 import com.larsreimann.safeds.staticAnalysis.typing.UnresolvedType
 import com.larsreimann.safeds.staticAnalysis.typing.type
+import com.larsreimann.safeds.utils.ExperimentalSdsApi
 import com.larsreimann.safeds.utils.duplicatesBy
 import com.larsreimann.safeds.validation.AbstractSafeDSChecker
 import com.larsreimann.safeds.validation.codes.ErrorCode
@@ -115,6 +116,7 @@ class ClassChecker : AbstractSafeDSChecker() {
         }
     }
 
+    @OptIn(ExperimentalSdsApi::class)
     @Check
     fun multipleProtocols(sdsClass: SdsClass) {
         val protocols = sdsClass.protocolsOrEmpty()

--- a/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/validation/declarations/ClassChecker.kt
+++ b/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/validation/declarations/ClassChecker.kt
@@ -34,7 +34,7 @@ class ClassChecker : AbstractSafeDSChecker() {
                     "A class must not directly or indirectly be a subtype of itself.",
                     it,
                     null,
-                    ErrorCode.CLASS_MUST_NOT_BE_SUBTYPE_OF_ITSELF
+                    ErrorCode.CLASS_MUST_NOT_BE_SUBTYPE_OF_ITSELF,
                 )
             }
     }
@@ -45,7 +45,7 @@ class ClassChecker : AbstractSafeDSChecker() {
             info(
                 "Unnecessary class body.",
                 Literals.SDS_CLASS__BODY,
-                InfoCode.UnnecessaryBody
+                InfoCode.UnnecessaryBody,
             )
         }
     }
@@ -62,7 +62,7 @@ class ClassChecker : AbstractSafeDSChecker() {
                     "A class must only inherit classes.",
                     it,
                     null,
-                    ErrorCode.CLASS_MUST_INHERIT_ONLY_CLASSES
+                    ErrorCode.CLASS_MUST_INHERIT_ONLY_CLASSES,
                 )
             }
     }
@@ -76,7 +76,7 @@ class ClassChecker : AbstractSafeDSChecker() {
                     error(
                         "Inherits multiple members called '$name'.",
                         Literals.SDS_ABSTRACT_DECLARATION__NAME,
-                        ErrorCode.CLASS_MUST_HAVE_UNIQUE_INHERITED_MEMBERS
+                        ErrorCode.CLASS_MUST_HAVE_UNIQUE_INHERITED_MEMBERS,
                     )
                 }
             }
@@ -100,7 +100,7 @@ class ClassChecker : AbstractSafeDSChecker() {
                     "Parent types must be unique.",
                     it,
                     null,
-                    ErrorCode.CLASS_MUST_HAVE_UNIQUE_PARENT_TYPES
+                    ErrorCode.CLASS_MUST_HAVE_UNIQUE_PARENT_TYPES,
                 )
             }
     }
@@ -111,7 +111,7 @@ class ClassChecker : AbstractSafeDSChecker() {
             info(
                 "Unnecessary type parameter list.",
                 Literals.SDS_CLASS__TYPE_PARAMETER_LIST,
-                InfoCode.UnnecessaryTypeParameterList
+                InfoCode.UnnecessaryTypeParameterList,
             )
         }
     }
@@ -126,7 +126,7 @@ class ClassChecker : AbstractSafeDSChecker() {
                     "A class must have only one protocol.",
                     it,
                     null,
-                    ErrorCode.OneProtocolPerClass
+                    ErrorCode.OneProtocolPerClass,
                 )
             }
         }

--- a/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/validation/declarations/CompilationUnitChecker.kt
+++ b/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/validation/declarations/CompilationUnitChecker.kt
@@ -36,7 +36,7 @@ class CompilationUnitChecker : AbstractSafeDSChecker() {
                         "A stub file must not declare workflows, schemas or steps.",
                         it,
                         Literals.SDS_ABSTRACT_DECLARATION__NAME,
-                        ErrorCode.StubFileMustNotDeclareWorkflowsSchemasOrSteps
+                        ErrorCode.StubFileMustNotDeclareWorkflowsSchemasOrSteps,
                     )
                 }
         } else if (sdsCompilationUnit.isInFlowFile()) {
@@ -47,7 +47,7 @@ class CompilationUnitChecker : AbstractSafeDSChecker() {
                         "A workflow file must only declare workflows and steps.",
                         it,
                         Literals.SDS_ABSTRACT_DECLARATION__NAME,
-                        ErrorCode.WorkflowFileMustOnlyDeclareWorkflowsAndSteps
+                        ErrorCode.WorkflowFileMustOnlyDeclareWorkflowsAndSteps,
                     )
                 }
         } else if (sdsCompilationUnit.isInSchemaFile()) {
@@ -58,7 +58,7 @@ class CompilationUnitChecker : AbstractSafeDSChecker() {
                         "A schema file must only declare schemas.",
                         it,
                         Literals.SDS_ABSTRACT_DECLARATION__NAME,
-                        ErrorCode.SchemaFileMustOnlyDeclareSchemas
+                        ErrorCode.SchemaFileMustOnlyDeclareSchemas,
                     )
                 }
         }
@@ -76,7 +76,7 @@ class CompilationUnitChecker : AbstractSafeDSChecker() {
                     "A file with declarations must declare its package.",
                     it,
                     Literals.SDS_ABSTRACT_DECLARATION__NAME,
-                    ErrorCode.FileMustDeclarePackage
+                    ErrorCode.FileMustDeclarePackage,
                 )
             }
         }
@@ -99,7 +99,7 @@ class CompilationUnitChecker : AbstractSafeDSChecker() {
                         "A declaration with name '${it.importedNameOrNull()}' exists already in this file.",
                         it,
                         Literals.SDS_IMPORT__IMPORTED_NAMESPACE,
-                        ErrorCode.REDECLARATION
+                        ErrorCode.REDECLARATION,
                     )
                 }
                 it is SdsImport && it.alias != null -> {
@@ -107,7 +107,7 @@ class CompilationUnitChecker : AbstractSafeDSChecker() {
                         "A declaration with name '${it.importedNameOrNull()}' exists already in this file.",
                         it.alias,
                         Literals.SDS_IMPORT_ALIAS__NAME,
-                        ErrorCode.REDECLARATION
+                        ErrorCode.REDECLARATION,
                     )
                 }
                 it is SdsAbstractDeclaration -> {
@@ -115,7 +115,7 @@ class CompilationUnitChecker : AbstractSafeDSChecker() {
                         "A declaration with name '${it.name}' exists already in this file.",
                         it,
                         Literals.SDS_ABSTRACT_DECLARATION__NAME,
-                        ErrorCode.REDECLARATION
+                        ErrorCode.REDECLARATION,
                     )
                 }
             }
@@ -124,7 +124,6 @@ class CompilationUnitChecker : AbstractSafeDSChecker() {
 
     @Check(CheckType.NORMAL)
     fun uniqueNamesAcrossFiles(sdsCompilationUnit: SdsCompilationUnit) {
-
         // Since the stdlib is automatically loaded into a workspace, every declaration would be marked as a duplicate
         // when editing the stdlib
         if (sdsCompilationUnit.isInStubFile() && sdsCompilationUnit.name.startsWith("safeds")) {
@@ -139,7 +138,7 @@ class CompilationUnitChecker : AbstractSafeDSChecker() {
                     "A declaration with qualified name '$qualifiedName' exists already.",
                     member,
                     Literals.SDS_ABSTRACT_DECLARATION__NAME,
-                    ErrorCode.REDECLARATION_IN_OTHER_FILE
+                    ErrorCode.REDECLARATION_IN_OTHER_FILE,
                 )
             }
         }

--- a/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/validation/declarations/CompilationUnitChecker.kt
+++ b/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/validation/declarations/CompilationUnitChecker.kt
@@ -16,6 +16,7 @@ import com.larsreimann.safeds.safeDS.SdsSchema
 import com.larsreimann.safeds.safeDS.SdsStep
 import com.larsreimann.safeds.safeDS.SdsWorkflow
 import com.larsreimann.safeds.scoping.externalGlobalDeclarations
+import com.larsreimann.safeds.utils.ExperimentalSdsApi
 import com.larsreimann.safeds.utils.duplicatesBy
 import com.larsreimann.safeds.validation.AbstractSafeDSChecker
 import com.larsreimann.safeds.validation.codes.ErrorCode
@@ -24,6 +25,7 @@ import org.eclipse.xtext.validation.CheckType
 
 class CompilationUnitChecker : AbstractSafeDSChecker() {
 
+    @OptIn(ExperimentalSdsApi::class)
     @Check
     fun members(sdsCompilationUnit: SdsCompilationUnit) {
         if (sdsCompilationUnit.isInStubFile()) {

--- a/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/validation/declarations/TypeParameterChecker.kt
+++ b/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/validation/declarations/TypeParameterChecker.kt
@@ -6,12 +6,14 @@ import com.larsreimann.safeds.constant.kind
 import com.larsreimann.safeds.constant.variance
 import com.larsreimann.safeds.safeDS.SafeDSPackage.Literals
 import com.larsreimann.safeds.safeDS.SdsTypeParameter
+import com.larsreimann.safeds.utils.ExperimentalSdsApi
 import com.larsreimann.safeds.validation.AbstractSafeDSChecker
 import com.larsreimann.safeds.validation.codes.ErrorCode
 import org.eclipse.xtext.validation.Check
 
 class TypeParameterChecker : AbstractSafeDSChecker() {
 
+    @OptIn(ExperimentalSdsApi::class)
     @Check
     fun mustNotHaveVarianceAndKind(sdsTypeParameter: SdsTypeParameter) {
         if (sdsTypeParameter.variance() != SdsVariance.Invariant && sdsTypeParameter.kind() != SdsKind.NoKind) {

--- a/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/validation/declarations/TypeParameterChecker.kt
+++ b/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/validation/declarations/TypeParameterChecker.kt
@@ -20,7 +20,7 @@ class TypeParameterChecker : AbstractSafeDSChecker() {
             error(
                 "Can not use variance and kind together",
                 Literals.SDS_ABSTRACT_DECLARATION__NAME,
-                ErrorCode.VarianceAndKind
+                ErrorCode.VarianceAndKind,
             )
         }
     }

--- a/DSL/com.larsreimann.safeds/src/test/kotlin/com/larsreimann/safeds/emf/CreatorsTest.kt
+++ b/DSL/com.larsreimann.safeds/src/test/kotlin/com/larsreimann/safeds/emf/CreatorsTest.kt
@@ -63,7 +63,7 @@ class CreatorsTest {
     fun `createSdsAnnotation should store annotation uses in annotationCallList`() {
         val annotation = createSdsAnnotation(
             "Test",
-            listOf(createSdsAnnotationCall("Test"))
+            listOf(createSdsAnnotationCall("Test")),
         )
 
         annotation.annotationCalls.shouldHaveSize(0)
@@ -77,7 +77,7 @@ class CreatorsTest {
     fun `createSdsAnnotation should omit empty parameter lists`() {
         val annotation = createSdsAnnotation(
             "Test",
-            parameters = emptyList()
+            parameters = emptyList(),
         )
 
         annotation.parameterList.shouldBeNull()
@@ -96,7 +96,7 @@ class CreatorsTest {
     fun `createSdsAnnotationUse should omit empty argument lists`() {
         val annotationUse = createSdsAnnotationCall(
             "Test",
-            arguments = emptyList()
+            arguments = emptyList(),
         )
         annotationUse.argumentList.shouldBeNull()
     }
@@ -129,7 +129,7 @@ class CreatorsTest {
         val lambda = createSdsBlockLambda {
             sdsAssignment(
                 listOf(createSdsWildcard()),
-                createSdsInt(1)
+                createSdsInt(1),
             )
         }
 
@@ -143,7 +143,7 @@ class CreatorsTest {
         val workflow = createSdsWorkflow("Test") {
             sdsAssignment(
                 listOf(createSdsWildcard()),
-                createSdsInt(1)
+                createSdsInt(1),
             )
         }
 
@@ -157,7 +157,7 @@ class CreatorsTest {
         val step = createSdsStep("Test") {
             sdsAssignment(
                 listOf(createSdsWildcard()),
-                createSdsInt(1)
+                createSdsInt(1),
             )
         }
 
@@ -170,7 +170,7 @@ class CreatorsTest {
     fun `createSdsAttribute should store annotation uses in annotationCallList`() {
         val attribute = createSdsAttribute(
             "Test",
-            listOf(createSdsAnnotationCall("Test"))
+            listOf(createSdsAnnotationCall("Test")),
         )
 
         attribute.annotationCalls.shouldHaveSize(0)
@@ -220,7 +220,7 @@ class CreatorsTest {
     fun `createSdsCall should omit empty type argument lists`() {
         val call = createSdsCall(
             createSdsNull(),
-            typeArguments = emptyList()
+            typeArguments = emptyList(),
         )
         call.typeArgumentList.shouldBeNull()
     }
@@ -229,7 +229,7 @@ class CreatorsTest {
     fun `createSdsClass should store annotation uses in annotationCallList`() {
         val `class` = createSdsClass(
             "Test",
-            listOf(createSdsAnnotationCall("Test"))
+            listOf(createSdsAnnotationCall("Test")),
         )
 
         `class`.annotationCalls.shouldHaveSize(0)
@@ -243,7 +243,7 @@ class CreatorsTest {
     fun `createSdsClass should omit empty body`() {
         val `class` = createSdsClass(
             "Test",
-            members = emptyList()
+            members = emptyList(),
         )
         `class`.body.shouldBeNull()
     }
@@ -252,7 +252,7 @@ class CreatorsTest {
     fun `createSdsClass should not omit empty parameter lists`() {
         val `class` = createSdsClass(
             "Test",
-            parameters = emptyList()
+            parameters = emptyList(),
         )
         `class`.parameterList.shouldBeInstanceOf<SdsParameterList>()
     }
@@ -261,7 +261,7 @@ class CreatorsTest {
     fun `createSdsClass should omit empty parent type list`() {
         val `class` = createSdsClass(
             "Test",
-            parentTypes = emptyList()
+            parentTypes = emptyList(),
         )
         `class`.parentTypeList.shouldBeNull()
     }
@@ -270,7 +270,7 @@ class CreatorsTest {
     fun `createSdsClass should omit empty type parameter list`() {
         val `class` = createSdsClass(
             "Test",
-            typeParameters = emptyList()
+            typeParameters = emptyList(),
         )
         `class`.typeParameterList.shouldBeNull()
     }
@@ -310,7 +310,7 @@ class CreatorsTest {
     fun `createSdsCompilationUnit should store annotation uses in annotationCalls`() {
         val compilationUnit = createSdsCompilationUnit(
             packageName = "test",
-            listOf(createSdsAnnotationCall("Test"))
+            listOf(createSdsAnnotationCall("Test")),
         )
 
         compilationUnit.annotationCalls.shouldHaveSize(1)
@@ -321,7 +321,7 @@ class CreatorsTest {
     fun `createSdsEnum should store annotation uses in annotationCallList`() {
         val `enum` = createSdsEnum(
             "Test",
-            listOf(createSdsAnnotationCall("Test"))
+            listOf(createSdsAnnotationCall("Test")),
         )
 
         `enum`.annotationCalls.shouldHaveSize(0)
@@ -335,7 +335,7 @@ class CreatorsTest {
     fun `createSdsEnum should omit empty body`() {
         val enum = createSdsEnum(
             "Test",
-            variants = emptyList()
+            variants = emptyList(),
         )
         enum.body.shouldBeNull()
     }
@@ -364,7 +364,7 @@ class CreatorsTest {
     fun `createSdsEnumVariant should store annotation uses in annotations`() {
         val variant = createSdsEnumVariant(
             "Test",
-            listOf(createSdsAnnotationCall("Test"))
+            listOf(createSdsAnnotationCall("Test")),
         )
 
         variant.annotationCalls.shouldHaveSize(1)
@@ -375,7 +375,7 @@ class CreatorsTest {
     fun `createSdsEnumVariant should omit empty type parameter list`() {
         val enum = createSdsEnumVariant(
             "Test",
-            typeParameters = emptyList()
+            typeParameters = emptyList(),
         )
         enum.typeParameterList.shouldBeNull()
     }
@@ -384,7 +384,7 @@ class CreatorsTest {
     fun `createSdsEnumVariant should omit empty parameter list`() {
         val enum = createSdsEnumVariant(
             "Test",
-            parameters = emptyList()
+            parameters = emptyList(),
         )
         enum.parameterList.shouldBeNull()
     }
@@ -392,7 +392,7 @@ class CreatorsTest {
     @Test
     fun `createSdsEnumVariant should omit empty constraint list`() {
         val enum = createSdsEnumVariant(
-            "Test"
+            "Test",
         )
         enum.constraint.shouldBeNull()
     }
@@ -476,7 +476,7 @@ class CreatorsTest {
     fun `createSdsFunction should store annotation uses in annotationCallList`() {
         val function = createSdsFunction(
             "test",
-            listOf(createSdsAnnotationCall("Test"))
+            listOf(createSdsAnnotationCall("Test")),
         )
 
         function.annotationCalls.shouldHaveSize(0)
@@ -490,7 +490,7 @@ class CreatorsTest {
     fun `createSdsFunction should omit empty result list`() {
         val function = createSdsFunction(
             "test",
-            results = emptyList()
+            results = emptyList(),
         )
         function.resultList.shouldBeNull()
     }
@@ -499,7 +499,7 @@ class CreatorsTest {
     fun `createSdsFunction should omit empty type parameter list`() {
         val function = createSdsFunction(
             "test",
-            typeParameters = emptyList()
+            typeParameters = emptyList(),
         )
         function.typeParameterList.shouldBeNull()
     }
@@ -551,7 +551,7 @@ class CreatorsTest {
     fun `createSdsNamedType should omit empty type argument lists`() {
         val namedType = createSdsNamedType(
             createSdsClass("Int"),
-            typeArguments = emptyList()
+            typeArguments = emptyList(),
         )
         namedType.typeArgumentList.shouldBeNull()
     }
@@ -560,7 +560,7 @@ class CreatorsTest {
     fun `createSdsParameter should store annotation uses in annotations`() {
         val parameter = createSdsParameter(
             "test",
-            listOf(createSdsAnnotationCall("Test"))
+            listOf(createSdsAnnotationCall("Test")),
         )
 
         parameter.annotationCalls.shouldHaveSize(1)
@@ -593,8 +593,8 @@ class CreatorsTest {
         shouldThrow<IllegalArgumentException> {
             createSdsProtocolAlternative(
                 listOf(
-                    createSdsProtocolTokenClass(SdsProtocolTokenClassValue.Anything)
-                )
+                    createSdsProtocolTokenClass(SdsProtocolTokenClassValue.Anything),
+                ),
             )
         }
 
@@ -603,7 +603,7 @@ class CreatorsTest {
                 listOf(
                     createSdsProtocolTokenClass(SdsProtocolTokenClassValue.Anything),
                     createSdsProtocolTokenClass(SdsProtocolTokenClassValue.Anything),
-                )
+                ),
             )
         }
     }
@@ -623,8 +623,8 @@ class CreatorsTest {
         shouldThrow<IllegalArgumentException> {
             createSdsProtocolSequence(
                 listOf(
-                    createSdsProtocolTokenClass(SdsProtocolTokenClassValue.Anything)
-                )
+                    createSdsProtocolTokenClass(SdsProtocolTokenClassValue.Anything),
+                ),
             )
         }
 
@@ -633,7 +633,7 @@ class CreatorsTest {
                 listOf(
                     createSdsProtocolTokenClass(SdsProtocolTokenClassValue.Anything),
                     createSdsProtocolTokenClass(SdsProtocolTokenClassValue.Anything),
-                )
+                ),
             )
         }
     }
@@ -653,7 +653,7 @@ class CreatorsTest {
     fun `createSdsResult should store annotation uses in annotations`() {
         val result = createSdsResult(
             "Test",
-            listOf(createSdsAnnotationCall("Test"))
+            listOf(createSdsAnnotationCall("Test")),
         )
 
         result.annotationCalls.shouldHaveSize(1)
@@ -665,7 +665,7 @@ class CreatorsTest {
         shouldThrow<IllegalArgumentException> {
             createSdsTemplateString(
                 listOf("Test"),
-                listOf(createSdsInt(1))
+                listOf(createSdsInt(1)),
             )
         }
     }
@@ -675,7 +675,7 @@ class CreatorsTest {
         shouldThrow<IllegalArgumentException> {
             createSdsTemplateString(
                 listOf("Test", "Test"),
-                listOf()
+                listOf(),
             )
         }
     }
@@ -685,7 +685,7 @@ class CreatorsTest {
         shouldThrow<IllegalArgumentException> {
             createSdsTemplateString(
                 listOf("Test", "Test", "Test"),
-                listOf(createSdsInt(1))
+                listOf(createSdsInt(1)),
             )
         }
     }
@@ -694,7 +694,7 @@ class CreatorsTest {
     fun `createSdsTemplate should interleave string parts and template expressions`() {
         val templateString = createSdsTemplateString(
             listOf("Start", "Inner", "Inner", "End"),
-            listOf(createSdsInt(1), createSdsInt(1), createSdsInt(1))
+            listOf(createSdsInt(1), createSdsInt(1), createSdsInt(1)),
         )
 
         templateString.expressions.asClue {
@@ -713,7 +713,7 @@ class CreatorsTest {
     fun `createSdsTypeArgument should create an SdsTypeParameter when only a name is passed`() {
         val typeArgument = createSdsTypeArgument(
             createSdsStarProjection(),
-            "Test"
+            "Test",
         )
         val typeParameter = typeArgument.typeParameter
         typeParameter.shouldNotBeNull()
@@ -724,7 +724,7 @@ class CreatorsTest {
     fun `createSdsTypeParameter should store annotation uses in annotations`() {
         val result = createSdsTypeParameter(
             "Test",
-            listOf(createSdsAnnotationCall("Test"))
+            listOf(createSdsAnnotationCall("Test")),
         )
 
         result.annotationCalls.shouldHaveSize(1)
@@ -736,7 +736,7 @@ class CreatorsTest {
         val constraint = createSdsTypeParameterConstraintGoal(
             "Test",
             SdsTypeParameterConstraintOperator.SubclassOf,
-            createSdsNamedType(createSdsClass("Test"))
+            createSdsNamedType(createSdsClass("Test")),
         )
         val leftOperand = constraint.leftOperand
         leftOperand.shouldNotBeNull()
@@ -753,9 +753,9 @@ class CreatorsTest {
             createSdsUnionType(
                 listOf(
                     createSdsTypeArgument(
-                        createSdsStarProjection()
-                    )
-                )
+                        createSdsStarProjection(),
+                    ),
+                ),
             )
         }
     }
@@ -772,7 +772,7 @@ class CreatorsTest {
     fun `createSdsStep should store annotation uses in annotationCallList`() {
         val step = createSdsStep(
             "test",
-            listOf(createSdsAnnotationCall("Test"))
+            listOf(createSdsAnnotationCall("Test")),
         )
 
         step.annotationCalls.shouldHaveSize(0)
@@ -786,7 +786,7 @@ class CreatorsTest {
     fun `createSdsStep should omit empty result list`() {
         val function = createSdsStep(
             "test",
-            results = emptyList()
+            results = emptyList(),
         )
         function.resultList.shouldBeNull()
     }
@@ -804,7 +804,7 @@ class CreatorsTest {
     fun `createSdsWorkflow should store annotation uses in annotationCallList`() {
         val workflow = createSdsWorkflow(
             "test",
-            listOf(createSdsAnnotationCall("Test"))
+            listOf(createSdsAnnotationCall("Test")),
         )
 
         workflow.annotationCalls.shouldHaveSize(0)

--- a/DSL/com.larsreimann.safeds/src/test/kotlin/com/larsreimann/safeds/emf/CreatorsTest.kt
+++ b/DSL/com.larsreimann.safeds/src/test/kotlin/com/larsreimann/safeds/emf/CreatorsTest.kt
@@ -17,6 +17,7 @@ import com.larsreimann.safeds.serializer.SerializationResult
 import com.larsreimann.safeds.serializer.serializeToFormattedString
 import com.larsreimann.safeds.testing.SafeDSInjectorProvider
 import com.larsreimann.safeds.testing.assertions.shouldBeCloseTo
+import com.larsreimann.safeds.utils.ExperimentalSdsApi
 import io.kotest.assertions.asClue
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldThrow
@@ -45,6 +46,7 @@ import org.junit.jupiter.api.extension.ExtendWith
  * - Template string creator should check structure of template string
  * - Union type requires at least one type argument
  */
+@OptIn(ExperimentalSdsApi::class)
 @ExtendWith(InjectionExtension::class)
 @InjectWith(SafeDSInjectorProvider::class)
 class CreatorsTest {

--- a/DSL/com.larsreimann.safeds/src/test/kotlin/com/larsreimann/safeds/staticAnalysis/linking/TypeArgumentToTypeParameterTest.kt
+++ b/DSL/com.larsreimann.safeds/src/test/kotlin/com/larsreimann/safeds/staticAnalysis/linking/TypeArgumentToTypeParameterTest.kt
@@ -42,7 +42,7 @@ class TypeArgumentToTypeParameterTest {
         typeParameter = createSdsTypeParameter(name = "T")
 
         positionalTypeArgument = createSdsTypeArgument(
-            value = createSdsStarProjection()
+            value = createSdsStarProjection(),
         )
         namedTypeArgument = createSdsTypeArgument(
             value = createSdsStarProjection(),
@@ -51,7 +51,7 @@ class TypeArgumentToTypeParameterTest {
 
         function = createSdsFunction(name = "f")
         call = createSdsCall(
-            createSdsReference(function)
+            createSdsReference(function),
         )
 
         `class` = createSdsClass(name = "C")

--- a/DSL/com.larsreimann.safeds/src/test/kotlin/com/larsreimann/safeds/staticAnalysis/linking/TypeArgumentToTypeParameterTest.kt
+++ b/DSL/com.larsreimann.safeds/src/test/kotlin/com/larsreimann/safeds/staticAnalysis/linking/TypeArgumentToTypeParameterTest.kt
@@ -16,6 +16,7 @@ import com.larsreimann.safeds.safeDS.SdsFunction
 import com.larsreimann.safeds.safeDS.SdsNamedType
 import com.larsreimann.safeds.safeDS.SdsTypeArgument
 import com.larsreimann.safeds.safeDS.SdsTypeParameter
+import com.larsreimann.safeds.utils.ExperimentalSdsApi
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
@@ -23,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
+@OptIn(ExperimentalSdsApi::class)
 class TypeArgumentToTypeParameterTest {
     private lateinit var typeParameter: SdsTypeParameter
 

--- a/DSL/com.larsreimann.safeds/src/test/kotlin/com/larsreimann/safeds/staticAnalysis/schema/InitialSchemaInferenceTest.kt
+++ b/DSL/com.larsreimann.safeds/src/test/kotlin/com/larsreimann/safeds/staticAnalysis/schema/InitialSchemaInferenceTest.kt
@@ -9,6 +9,7 @@ import com.larsreimann.safeds.serializer.serializeToFormattedString
 import com.larsreimann.safeds.testing.ParseHelper
 import com.larsreimann.safeds.testing.SafeDSInjectorProvider
 import com.larsreimann.safeds.testing.getResourcePath
+import com.larsreimann.safeds.utils.ExperimentalSdsApi
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -44,6 +45,7 @@ class InitialSchemaInferenceTest {
     """.trimMargin()
 
     @Test
+    @OptIn(ExperimentalSdsApi::class)
     fun inferInitialSchema() {
         val context = parseHelper.parseProgramText("package test")
         context.shouldNotBeNull()

--- a/DSL/com.larsreimann.safeds/src/testFixtures/kotlin/com/larsreimann/safeds/testing/TestResourceUtils.kt
+++ b/DSL/com.larsreimann.safeds/src/testFixtures/kotlin/com/larsreimann/safeds/testing/TestResourceUtils.kt
@@ -1,6 +1,7 @@
 package com.larsreimann.safeds.testing
 
 import com.larsreimann.safeds.constant.SdsFileExtension
+import com.larsreimann.safeds.utils.ExperimentalSdsApi
 import org.eclipse.core.runtime.FileLocator
 import org.eclipse.emf.common.util.URI
 import org.junit.jupiter.api.DynamicContainer
@@ -62,6 +63,7 @@ private fun createDynamicTestFromResource(
     }
 }
 
+@OptIn(ExperimentalSdsApi::class)
 private fun isTestFile(filePath: Path): Boolean {
     return Files.isRegularFile(filePath) &&
         (

--- a/DSL/com.larsreimann.safeds/src/testFixtures/kotlin/com/larsreimann/safeds/testing/TestResourceUtils.kt
+++ b/DSL/com.larsreimann.safeds/src/testFixtures/kotlin/com/larsreimann/safeds/testing/TestResourceUtils.kt
@@ -27,7 +27,7 @@ fun ClassLoader.getResourceEmfUri(fileOrFolder: String): URI? {
 
 fun Path.createDynamicTestsFromResourceFolder(
     validator: (resourcePath: Path, filePath: Path, program: String) -> String?,
-    categorizedTestCreator: (resourcePath: Path, filePath: Path, program: String) -> Sequence<CategorizedTest>
+    categorizedTestCreator: (resourcePath: Path, filePath: Path, program: String) -> Sequence<CategorizedTest>,
 ): Stream<out DynamicNode> {
     return Files.walk(this)
         .asSequence()
@@ -44,7 +44,7 @@ private fun createDynamicTestFromResource(
     resourcePath: Path,
     filePath: Path,
     validator: (resourcePath: Path, filePath: Path, program: String) -> String?,
-    categorizedTestCreator: (resourcePath: Path, filePath: Path, program: String) -> Sequence<CategorizedTest>
+    categorizedTestCreator: (resourcePath: Path, filePath: Path, program: String) -> Sequence<CategorizedTest>,
 ) = sequence {
     val program = Files.readString(filePath)
 
@@ -55,8 +55,8 @@ private fun createDynamicTestFromResource(
                 "### BAD TEST FILE ###",
                 DynamicTest.dynamicTest(testDisplayName(resourcePath, filePath), filePath.toUri()) {
                     throw IllegalArgumentException(testFileError)
-                }
-            )
+                },
+            ),
         )
     } else {
         yieldAll(categorizedTestCreator(resourcePath, filePath, program))

--- a/docs/Development/how-to-add-a-new-language-concept.md
+++ b/docs/Development/how-to-add-a-new-language-concept.md
@@ -14,11 +14,11 @@
     1. Update the [Xtext grammar file][safeds.xtext].
     1. Run the tests again (`./gradlew test`). Tests should now pass.
 
-1. Update the [constants][constants] if the concrete syntax of your concept has terminals that need to be accessed programmatically (e.g. operators or modifiers).
+1. Update the [constants][constants] if the concrete syntax of your concept has terminals that need to be accessed programmatically (e.g. operators or modifiers). Mark new declarations with [`@ExperimentalSdsApi`][experimental-sds-api].
 
-1. Update the [creators][creators], which simplify the creation of instances of model classes. There should be at least one function for each class.
+1. Update the [creators][creators], which simplify the creation of instances of model classes. There should be at least one function for each class.  Mark new declarations with [`@ExperimentalSdsApi`][experimental-sds-api].
 
-1. Update the [access shortcuts][shortcuts], which simplify the traversal of the EMF model. This is not always required and the file should only contain functions that are simple enough to not require tests.
+1. Update the [access shortcuts][shortcuts], which simplify the traversal of the EMF model. This is not always required and the file should only contain functions that are simple enough to not require tests.  Mark new declarations with [`@ExperimentalSdsApi`][experimental-sds-api].
 
 1. Update the converters if your concept includes terminals where the value they represent differs from their textual representation.
 
@@ -36,7 +36,7 @@
 
 1. Update the [resource description strategy][resource-description-strategy] if your concept is a declaration that should be visible from another file.
 
-1. Update the [static analyses][static-analysis].
+1. Update the [static analyses][static-analysis]. Mark new declarations with [`@ExperimentalSdsApi`][experimental-sds-api].
 
 1. Update the validator.
 
@@ -63,6 +63,7 @@
 
 <!-- Links -->
 
+[experimental-sds-api]: ../../DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/utils/MarkerAnnotations.kt
 [safeds.ecore]: ../../DSL/com.larsreimann.safeds/model/SafeDS.ecore
 [safeds.genmodel]: ../../DSL/com.larsreimann.safeds/model/SafeDS.genmodel
 [grammar-tests]: ../../DSL/com.larsreimann.safeds/src/test/resources/grammar

--- a/docs/Development/how-to-add-a-new-language-concept.md
+++ b/docs/Development/how-to-add-a-new-language-concept.md
@@ -16,9 +16,9 @@
 
 1. Update the [constants][constants] if the concrete syntax of your concept has terminals that need to be accessed programmatically (e.g. operators or modifiers). Mark new declarations with [`@ExperimentalSdsApi`][experimental-sds-api].
 
-1. Update the [creators][creators], which simplify the creation of instances of model classes. There should be at least one function for each class.  Mark new declarations with [`@ExperimentalSdsApi`][experimental-sds-api].
+1. Update the [creators][creators], which simplify the creation of instances of model classes. There should be at least one function for each class. Mark new declarations with [`@ExperimentalSdsApi`][experimental-sds-api].
 
-1. Update the [access shortcuts][shortcuts], which simplify the traversal of the EMF model. This is not always required and the file should only contain functions that are simple enough to not require tests.  Mark new declarations with [`@ExperimentalSdsApi`][experimental-sds-api].
+1. Update the [access shortcuts][shortcuts], which simplify the traversal of the EMF model. This is not always required and the file should only contain functions that are simple enough to not require tests. Mark new declarations with [`@ExperimentalSdsApi`][experimental-sds-api].
 
 1. Update the converters if your concept includes terminals where the value they represent differs from their textual representation.
 


### PR DESCRIPTION
### Summary of Changes

Particularly the creators are also of interest for the https://github.com/lars-reimann/api-editor. Their interface should be stable and experimental parts should be highlighted as such. This is now possible with the annotation `@ExperimentalSdsApi`. I've retroactively added this annotations to appropriate declarations.

In the future this annotation should be added to all new

* constants (`constant/**`)
* creators (`emf/Creators.kt`)
* shortcuts (`emf/SimpleShortcuts.kt`)
* static analyses (`staticAnalysis/**`)
