### PR TITLE
chore: change disable_rules to ktlint_disabled_rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,6 @@ insert_final_newline = true
 indent_size = 2
 
 [*.{kt,kts}]
-disabled_rules = filename
+ktlint_disabled_rules = filename
 ij_kotlin_allow_trailing_comma = true
 ij_kotlin_allow_trailing_comma_on_call_site = true


### PR DESCRIPTION
The old `disabled_rules` property is now deprecated.
