### PR TITLE
ci: skip build jobs of unchanged components

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,9 +9,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Run change detection
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      dsl: ${{ steps.filter.outputs.dsl }}
+      runner: ${{ steps.filter.outputs.runner }}
+      stdlib: ${{ steps.filter.outputs.stdlib }}
+    steps:
+      - uses: dorny/paths-filter@v2.11.1
+        id: filter
+        with:
+          filters: |
+            dsl:
+              - 'DSL/**'
+            runner:
+              - 'Runtime/safe-ds-runner/**'
+            stdlib:
+              - 'Runtime/safe-ds/**'
 
   # Build and test DSL component
   build-dsl:
+    needs: changes
+    if: ${{ needs.changes.outputs.dsl == 'true' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -58,6 +80,8 @@ jobs:
 
   # Build and test Runtime > Runner component
   build-runtime-runner:
+    needs: changes
+    if: ${{ needs.changes.outputs.runner == 'true' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -107,6 +131,8 @@ jobs:
 
   # Build and test Runtime > Stdlib component
   build-runtime-stdlib:
+    needs: changes
+    if: ${{ needs.changes.outputs.stdlib == 'true' }}
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
### Summary of Changes

Unchanged components are no longer build as part of the PR workflow. This saves quota and developers of the standard library no longer need to wait for the DSL to build.