### PR TITLE
ci: disable pylint duplicate check

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -34,6 +34,7 @@ disable=
     import-error,
     # Unwanted
     design,
+    duplicate-code,
     metrics,
     logging-fstring-interpolation,
     too-many-nested-blocks


### PR DESCRIPTION
### Summary of Changes

The check used to cause several false positives for example for `__eq__` or `__hash__` methods, which must always have a similar structure.