### PR TITLE
ci: fix incorrect options in mypy config

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
+disallow_incomplete_defs = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
 ignore_missing_imports = true
-disallow_untyped-calls = true
-disallow_untyped-defs = true
-disallow_incomplete-defs = true
-disallow_untyped-decorators = true


### PR DESCRIPTION
### Summary of Changes

Some `mypy` options were spelled incorrectly with a hyphen instead of an underscore. These are now fixed.
