### PR TITLE
ci: disable several mypy checks

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,6 +1,4 @@
 [mypy]
 disallow_incomplete_defs = true
-disallow_untyped_calls = true
-disallow_untyped_decorators = true
 disallow_untyped_defs = true
 ignore_missing_imports = true


### PR DESCRIPTION
### Summary of Changes

The following `mypy` checks are now disabled:
* `disallow_untyped_calls` (we cannot influence whether third-party functions have type hints)
* `disallow_untyped_decorators` (we cannot influence whether third-party decorators have type hints)
