### PR TITLE
fix: hide `column` attribute of `ColumnStatistics`

### DIFF
--- a/Runtime/safe-ds/safe_ds/data/__init__.py
+++ b/Runtime/safe-ds/safe_ds/data/__init__.py
@@ -7,7 +7,7 @@ from ._column_type import (
     OptionalColumnType,
     StringColumnType,
 )
-from ._row import  Row
+from ._row import Row
 from ._supervised_dataset import SupervisedDataset
 from ._table import Table
 from ._table_schema import TableSchema


### PR DESCRIPTION
### Summary of Changes

In class `ColumnStatistics` rename attribute `column` to `_column` so it no longer shows up in autocompletion.
