### PR TITLE
refactor: create `TableSchema` from dict instead of two lists

### DIFF
--- a/Runtime/safe-ds/safe_ds/data/_table_schema.py
+++ b/Runtime/safe-ds/safe_ds/data/_table_schema.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import pandas as pd
-
 from safe_ds.exceptions import UnknownColumnNameError
+
 from ._column_type import ColumnType
 
 

--- a/Runtime/safe-ds/tests/data/_row/test_to_rows.py
+++ b/Runtime/safe-ds/tests/data/_row/test_to_rows.py
@@ -1,6 +1,5 @@
 import pandas as pd
-
-from safe_ds.data import Row, StringColumnType, Table, TableSchema, IntColumnType
+from safe_ds.data import IntColumnType, Row, StringColumnType, Table, TableSchema
 
 
 def test_to_rows() -> None:

--- a/Runtime/safe-ds/tests/data/_table/test_add_row.py
+++ b/Runtime/safe-ds/tests/data/_table/test_add_row.py
@@ -18,9 +18,6 @@ def test_add_row_invalid() -> None:
         table1 = Table(pd.DataFrame(data={"col1": [1, 2, 1], "col2": [1, 2, 4]}))
         row = Row(
             pd.Series(data=[5, "Hallo"]),
-            TableSchema({
-                "col1": IntColumnType(),
-                "col2": StringColumnType()
-            }),
+            TableSchema({"col1": IntColumnType(), "col2": StringColumnType()}),
         )
         table1 = table1.add_row(row)

--- a/Runtime/safe-ds/tests/data/_table_schema/test_table_equals.py
+++ b/Runtime/safe-ds/tests/data/_table_schema/test_table_equals.py
@@ -1,4 +1,4 @@
-from safe_ds.data import Table, TableSchema, IntColumnType, FloatColumnType
+from safe_ds.data import FloatColumnType, IntColumnType, Table, TableSchema
 
 
 def test_table_equals_valid() -> None:


### PR DESCRIPTION
### Summary of Changes

The constructor of `TableSchema` now expects a dict mapping column names to column types instead of two separate lists.
