### PR TITLE
refactor: Target column names are no longer hardcoded

### DIFF
--- a/Runtime/safe-ds/safe_ds/_util/_util_sklearn.py
+++ b/Runtime/safe-ds/safe_ds/_util/_util_sklearn.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from safe_ds.data import SupervisedDataset, Table
 from safe_ds.exceptions import LearningError, PredictionError

--- a/Runtime/safe-ds/safe_ds/_util/_util_sklearn.py
+++ b/Runtime/safe-ds/safe_ds/_util/_util_sklearn.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Optional
 
 from safe_ds.data import SupervisedDataset, Table
 from safe_ds.exceptions import LearningError, PredictionError
@@ -6,7 +6,7 @@ from sklearn.exceptions import NotFittedError
 
 
 # noinspection PyProtectedMember
-def fit(model: Any, supervised_dataset: SupervisedDataset) -> None:
+def fit(model: Any, supervised_dataset: SupervisedDataset) -> str:
     """
     Fit a model for a given supervised dataset.
 
@@ -16,6 +16,11 @@ def fit(model: Any, supervised_dataset: SupervisedDataset) -> None:
         Classifier or Regression from scikit-learn
     supervised_dataset: SupervisedDataset
         the supervised dataset containing the feature and target vectors
+
+    Returns
+    -------
+    target_name: str
+        The target column name, inferred from the supervised dataset
 
     Raises
     ------
@@ -27,6 +32,7 @@ def fit(model: Any, supervised_dataset: SupervisedDataset) -> None:
             supervised_dataset.feature_vectors._data,
             supervised_dataset.target_values._data,
         )
+        return supervised_dataset.target_values.name
     except ValueError as exception:
         raise LearningError(str(exception)) from exception
     except Exception as exception:
@@ -34,7 +40,7 @@ def fit(model: Any, supervised_dataset: SupervisedDataset) -> None:
 
 
 # noinspection PyProtectedMember
-def predict(model: Any, dataset: Table) -> Table:
+def predict(model: Any, dataset: Table, target_name: str) -> Table:
     """
     Predict a target vector using a dataset containing feature vectors. The model has to be trained first
 
@@ -44,6 +50,8 @@ def predict(model: Any, dataset: Table) -> Table:
         Classifier or Regression from scikit-learn
     dataset: Table
         the dataset containing the feature vectors
+    target_name: str
+        the name of the target vector, the name of the target column inferred from fit is used by default
 
     Returns
     -------
@@ -60,11 +68,11 @@ def predict(model: Any, dataset: Table) -> Table:
     try:
         predicted_target_vector = model.predict(dataset_df)
         result_set = dataset_df.copy(deep=True)
-        if "target_predictions" in result_set.columns:
+        if target_name in result_set.columns:
             raise ValueError(
-                "Dataset already contains 'target_predictions' column. Please rename this column"
+                f"Dataset already contains '{target_name}' column. Please rename this column"
             )
-        result_set["target_predictions"] = predicted_target_vector
+        result_set[target_name] = predicted_target_vector
         return Table(result_set)
     except NotFittedError as exception:
         raise PredictionError("The model was not trained") from exception

--- a/Runtime/safe-ds/safe_ds/classification/_ada_boost.py
+++ b/Runtime/safe-ds/safe_ds/classification/_ada_boost.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 # noinspection PyProtectedMember
 import safe_ds._util._util_sklearn
 from safe_ds.data import SupervisedDataset, Table
@@ -13,6 +15,7 @@ class AdaBoost:
 
     def __init__(self) -> None:
         self._classification = sk_AdaBoostClassifier()
+        self.target_name = ""
 
     def fit(self, supervised_dataset: SupervisedDataset) -> None:
         """
@@ -28,9 +31,9 @@ class AdaBoost:
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        safe_ds._util._util_sklearn.fit(self._classification, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(self._classification, supervised_dataset)
 
-    def predict(self, dataset: Table) -> Table:
+    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first
 
@@ -38,6 +41,8 @@ class AdaBoost:
         ----------
         dataset: Table
             the dataset containing the feature vectors
+        target_name: Optional[str]
+            the name of the target vector, the name of the target column inferred from fit is used by default
 
         Returns
         -------
@@ -49,4 +54,4 @@ class AdaBoost:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._classification, dataset)
+        return safe_ds._util._util_sklearn.predict(self._classification, dataset, target_name if target_name is not None else self.target_name)

--- a/Runtime/safe-ds/safe_ds/classification/_ada_boost.py
+++ b/Runtime/safe-ds/safe_ds/classification/_ada_boost.py
@@ -31,7 +31,9 @@ class AdaBoost:
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        self.target_name = safe_ds._util._util_sklearn.fit(self._classification, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(
+            self._classification, supervised_dataset
+        )
 
     def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
@@ -54,4 +56,8 @@ class AdaBoost:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._classification, dataset, target_name if target_name is not None else self.target_name)
+        return safe_ds._util._util_sklearn.predict(
+            self._classification,
+            dataset,
+            target_name if target_name is not None else self.target_name,
+        )

--- a/Runtime/safe-ds/safe_ds/classification/_decision_tree.py
+++ b/Runtime/safe-ds/safe_ds/classification/_decision_tree.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 # noinspection PyProtectedMember
 import safe_ds._util._util_sklearn
 from safe_ds.data import SupervisedDataset, Table
@@ -13,6 +15,7 @@ class DecisionTree:
 
     def __init__(self) -> None:
         self._classification = sk_DecisionTreeClassifier()
+        self.target_name = ""
 
     def fit(self, supervised_dataset: SupervisedDataset) -> None:
         """
@@ -28,9 +31,9 @@ class DecisionTree:
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        safe_ds._util._util_sklearn.fit(self._classification, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(self._classification, supervised_dataset)
 
-    def predict(self, dataset: Table) -> Table:
+    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first
 
@@ -38,6 +41,8 @@ class DecisionTree:
         ----------
         dataset: Table
             the dataset containing the feature vectors
+        target_name: Optional[str]
+            the name of the target vector, the name of the target column inferred from fit is used by default
 
         Returns
         -------
@@ -49,4 +54,4 @@ class DecisionTree:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._classification, dataset)
+        return safe_ds._util._util_sklearn.predict(self._classification, dataset, target_name if target_name is not None else self.target_name)

--- a/Runtime/safe-ds/safe_ds/classification/_decision_tree.py
+++ b/Runtime/safe-ds/safe_ds/classification/_decision_tree.py
@@ -31,7 +31,9 @@ class DecisionTree:
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        self.target_name = safe_ds._util._util_sklearn.fit(self._classification, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(
+            self._classification, supervised_dataset
+        )
 
     def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
@@ -54,4 +56,8 @@ class DecisionTree:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._classification, dataset, target_name if target_name is not None else self.target_name)
+        return safe_ds._util._util_sklearn.predict(
+            self._classification,
+            dataset,
+            target_name if target_name is not None else self.target_name,
+        )

--- a/Runtime/safe-ds/safe_ds/classification/_gradient_boosting_classification.py
+++ b/Runtime/safe-ds/safe_ds/classification/_gradient_boosting_classification.py
@@ -32,7 +32,9 @@ class GradientBoosting:
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        self.target_name = safe_ds._util._util_sklearn.fit(self._classification, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(
+            self._classification, supervised_dataset
+        )
 
     # noinspection PyProtectedMember
     def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
@@ -56,4 +58,8 @@ class GradientBoosting:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._classification, dataset, target_name if target_name is not None else self.target_name)
+        return safe_ds._util._util_sklearn.predict(
+            self._classification,
+            dataset,
+            target_name if target_name is not None else self.target_name,
+        )

--- a/Runtime/safe-ds/safe_ds/classification/_gradient_boosting_classification.py
+++ b/Runtime/safe-ds/safe_ds/classification/_gradient_boosting_classification.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 # noinspection PyProtectedMember
 import safe_ds._util._util_sklearn
 from safe_ds.data import SupervisedDataset, Table
@@ -13,6 +15,7 @@ class GradientBoosting:
 
     def __init__(self) -> None:
         self._classification = GradientBoostingClassifier()
+        self.target_name = ""
 
     def fit(self, supervised_dataset: SupervisedDataset) -> None:
         """
@@ -23,15 +26,16 @@ class GradientBoosting:
         supervised_dataset: SupervisedDataset
             the supervised dataset containing the feature and target vectors
 
+
         Raises
         ------
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        safe_ds._util._util_sklearn.fit(self._classification, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(self._classification, supervised_dataset)
 
     # noinspection PyProtectedMember
-    def predict(self, dataset: Table) -> Table:
+    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first
 
@@ -39,6 +43,8 @@ class GradientBoosting:
         ----------
         dataset: Table
             the dataset containing the feature vectors
+        target_name: Optional[str]
+            the name of the target vector, the name of the target column inferred from fit is used by default
 
         Returns
         -------
@@ -50,4 +56,4 @@ class GradientBoosting:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._classification, dataset)
+        return safe_ds._util._util_sklearn.predict(self._classification, dataset, target_name if target_name is not None else self.target_name)

--- a/Runtime/safe-ds/safe_ds/classification/_k_nearest_neighbors.py
+++ b/Runtime/safe-ds/safe_ds/classification/_k_nearest_neighbors.py
@@ -35,7 +35,9 @@ class KNearestNeighbors:
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        self.target_name = safe_ds._util._util_sklearn.fit(self._classification, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(
+            self._classification, supervised_dataset
+        )
 
     def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
@@ -58,4 +60,8 @@ class KNearestNeighbors:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._classification, dataset, target_name if target_name is not None else self.target_name)
+        return safe_ds._util._util_sklearn.predict(
+            self._classification,
+            dataset,
+            target_name if target_name is not None else self.target_name,
+        )

--- a/Runtime/safe-ds/safe_ds/classification/_k_nearest_neighbors.py
+++ b/Runtime/safe-ds/safe_ds/classification/_k_nearest_neighbors.py
@@ -1,9 +1,12 @@
+from typing import Optional
+
 # noinspection PyProtectedMember
 import safe_ds._util._util_sklearn
 from safe_ds.data import SupervisedDataset, Table
 from sklearn.neighbors import KNeighborsClassifier
 
 
+# noinspection PyProtectedMember
 class KNearestNeighbors:
     """
     This class implements K-nearest-neighbors classifier. It can only be trained on a supervised dataset.
@@ -16,6 +19,7 @@ class KNearestNeighbors:
 
     def __init__(self, n_neighbors: int) -> None:
         self._classification = KNeighborsClassifier(n_jobs=-1, n_neighbors=n_neighbors)
+        self.target_name = ""
 
     def fit(self, supervised_dataset: SupervisedDataset) -> None:
         """
@@ -31,9 +35,9 @@ class KNearestNeighbors:
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        safe_ds._util._util_sklearn.fit(self._classification, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(self._classification, supervised_dataset)
 
-    def predict(self, dataset: Table) -> Table:
+    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first
 
@@ -41,6 +45,8 @@ class KNearestNeighbors:
         ----------
         dataset: Table
             the dataset containing the feature vectors
+        target_name: Optional[str]
+            the name of the target vector, the name of the target column inferred from fit is used by default
 
         Returns
         -------
@@ -52,4 +58,4 @@ class KNearestNeighbors:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._classification, dataset)
+        return safe_ds._util._util_sklearn.predict(self._classification, dataset, target_name if target_name is not None else self.target_name)

--- a/Runtime/safe-ds/safe_ds/classification/_logistic_regression.py
+++ b/Runtime/safe-ds/safe_ds/classification/_logistic_regression.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 # noinspection PyProtectedMember
 import safe_ds._util._util_sklearn
 from safe_ds.data import SupervisedDataset, Table
@@ -13,6 +15,7 @@ class LogisticRegression:
 
     def __init__(self) -> None:
         self._classification = sk_LogisticRegression(n_jobs=-1)
+        self.target_name = ""
 
     def fit(self, supervised_dataset: SupervisedDataset) -> None:
         """
@@ -28,9 +31,9 @@ class LogisticRegression:
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        safe_ds._util._util_sklearn.fit(self._classification, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(self._classification, supervised_dataset)
 
-    def predict(self, dataset: Table) -> Table:
+    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first
 
@@ -38,6 +41,8 @@ class LogisticRegression:
         ----------
         dataset: Table
             the dataset containing the feature vectors
+        target_name: Optional[str]
+            the name of the target vector, the name of the target column inferred from fit is used by default
 
         Returns
         -------
@@ -49,4 +54,4 @@ class LogisticRegression:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._classification, dataset)
+        return safe_ds._util._util_sklearn.predict(self._classification, dataset, target_name if target_name is not None else self.target_name)

--- a/Runtime/safe-ds/safe_ds/classification/_logistic_regression.py
+++ b/Runtime/safe-ds/safe_ds/classification/_logistic_regression.py
@@ -31,7 +31,9 @@ class LogisticRegression:
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        self.target_name = safe_ds._util._util_sklearn.fit(self._classification, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(
+            self._classification, supervised_dataset
+        )
 
     def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
@@ -54,4 +56,8 @@ class LogisticRegression:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._classification, dataset, target_name if target_name is not None else self.target_name)
+        return safe_ds._util._util_sklearn.predict(
+            self._classification,
+            dataset,
+            target_name if target_name is not None else self.target_name,
+        )

--- a/Runtime/safe-ds/safe_ds/classification/_random_forest.py
+++ b/Runtime/safe-ds/safe_ds/classification/_random_forest.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 # noinspection PyProtectedMember
 import safe_ds._util._util_sklearn
 from safe_ds.data import SupervisedDataset, Table
@@ -12,6 +14,7 @@ class RandomForest:
 
     def __init__(self) -> None:
         self._classification = RandomForestClassifier(n_jobs=-1)
+        self.target_name = ""
 
     def fit(self, supervised_dataset: SupervisedDataset) -> None:
         """
@@ -27,9 +30,9 @@ class RandomForest:
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        safe_ds._util._util_sklearn.fit(self._classification, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(self._classification, supervised_dataset)
 
-    def predict(self, dataset: Table) -> Table:
+    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first
 
@@ -37,6 +40,8 @@ class RandomForest:
         ----------
         dataset: Table
             the dataset containing the feature vectors
+        target_name: Optional[str]
+            the name of the target vector, the name of the target column inferred from fit is used by default
 
         Returns
         -------
@@ -48,4 +53,4 @@ class RandomForest:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._classification, dataset)
+        return safe_ds._util._util_sklearn.predict(self._classification, dataset, target_name if target_name is not None else self.target_name)

--- a/Runtime/safe-ds/safe_ds/classification/_random_forest.py
+++ b/Runtime/safe-ds/safe_ds/classification/_random_forest.py
@@ -30,7 +30,9 @@ class RandomForest:
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        self.target_name = safe_ds._util._util_sklearn.fit(self._classification, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(
+            self._classification, supervised_dataset
+        )
 
     def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
@@ -53,4 +55,8 @@ class RandomForest:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._classification, dataset, target_name if target_name is not None else self.target_name)
+        return safe_ds._util._util_sklearn.predict(
+            self._classification,
+            dataset,
+            target_name if target_name is not None else self.target_name,
+        )

--- a/Runtime/safe-ds/safe_ds/data/_column.py
+++ b/Runtime/safe-ds/safe_ds/data/_column.py
@@ -249,6 +249,17 @@ class Column:
             )
         return self._data.corr(other_column._data)
 
+    def get_unique_values(self) -> list[typing.Any]:
+        """
+        Returns a list of all unique values in the column.
+
+        Returns
+        -------
+        unique_values: list[any]
+            List of unique values of this column
+        """
+        return list(self._data.unique())
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Column):
             return NotImplemented

--- a/Runtime/safe-ds/safe_ds/regression/_ada_boost.py
+++ b/Runtime/safe-ds/safe_ds/regression/_ada_boost.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 # noinspection PyProtectedMember
 import safe_ds._util._util_sklearn
 from safe_ds.data import SupervisedDataset, Table
@@ -13,6 +15,7 @@ class AdaBoost:
 
     def __init__(self) -> None:
         self._regression = sk_AdaBoostRegressor()
+        self.target_name = ""
 
     def fit(self, supervised_dataset: SupervisedDataset) -> None:
         """
@@ -28,9 +31,9 @@ class AdaBoost:
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        safe_ds._util._util_sklearn.fit(self._regression, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(self._regression, supervised_dataset)
 
-    def predict(self, dataset: Table) -> Table:
+    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first
 
@@ -38,6 +41,8 @@ class AdaBoost:
         ----------
         dataset: Table
             the dataset containing the feature vectors
+        target_name: Optional[str]
+            the name of the target vector, the name of the target column inferred from fit is used by default
 
         Returns
         -------
@@ -49,4 +54,4 @@ class AdaBoost:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._regression, dataset)
+        return safe_ds._util._util_sklearn.predict(self._regression, dataset, target_name if target_name is not None else self.target_name)

--- a/Runtime/safe-ds/safe_ds/regression/_ada_boost.py
+++ b/Runtime/safe-ds/safe_ds/regression/_ada_boost.py
@@ -31,7 +31,9 @@ class AdaBoost:
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        self.target_name = safe_ds._util._util_sklearn.fit(self._regression, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(
+            self._regression, supervised_dataset
+        )
 
     def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
@@ -54,4 +56,8 @@ class AdaBoost:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._regression, dataset, target_name if target_name is not None else self.target_name)
+        return safe_ds._util._util_sklearn.predict(
+            self._regression,
+            dataset,
+            target_name if target_name is not None else self.target_name,
+        )

--- a/Runtime/safe-ds/safe_ds/regression/_decision_tree.py
+++ b/Runtime/safe-ds/safe_ds/regression/_decision_tree.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 # noinspection PyProtectedMember
 import safe_ds._util._util_sklearn
 from safe_ds.data import SupervisedDataset, Table
@@ -13,6 +15,7 @@ class DecisionTree:
 
     def __init__(self) -> None:
         self._regression = sk_DecisionTreeRegressor()
+        self.target_name = ""
 
     def fit(self, supervised_dataset: SupervisedDataset) -> None:
         """
@@ -28,9 +31,9 @@ class DecisionTree:
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        safe_ds._util._util_sklearn.fit(self._regression, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(self._regression, supervised_dataset)
 
-    def predict(self, dataset: Table) -> Table:
+    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first
 
@@ -38,6 +41,8 @@ class DecisionTree:
         ----------
         dataset: Table
             the dataset containing the feature vectors
+        target_name: Optional[str]
+            the name of the target vector, the name of the target column inferred from fit is used by default
 
         Returns
         -------
@@ -49,4 +54,4 @@ class DecisionTree:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._regression, dataset)
+        return safe_ds._util._util_sklearn.predict(self._regression, dataset, target_name if target_name is not None else self.target_name)

--- a/Runtime/safe-ds/safe_ds/regression/_decision_tree.py
+++ b/Runtime/safe-ds/safe_ds/regression/_decision_tree.py
@@ -31,7 +31,9 @@ class DecisionTree:
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        self.target_name = safe_ds._util._util_sklearn.fit(self._regression, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(
+            self._regression, supervised_dataset
+        )
 
     def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
@@ -54,4 +56,8 @@ class DecisionTree:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._regression, dataset, target_name if target_name is not None else self.target_name)
+        return safe_ds._util._util_sklearn.predict(
+            self._regression,
+            dataset,
+            target_name if target_name is not None else self.target_name,
+        )

--- a/Runtime/safe-ds/safe_ds/regression/_elastic_net_regression.py
+++ b/Runtime/safe-ds/safe_ds/regression/_elastic_net_regression.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 # noinspection PyProtectedMember
 import safe_ds._util._util_sklearn
 from safe_ds.data import SupervisedDataset, Table
@@ -13,6 +15,7 @@ class ElasticNetRegression:
 
     def __init__(self) -> None:
         self._regression = sk_ElasticNet()
+        self.target_name = ""
 
     def fit(self, supervised_dataset: SupervisedDataset) -> None:
         """
@@ -28,9 +31,9 @@ class ElasticNetRegression:
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        safe_ds._util._util_sklearn.fit(self._regression, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(self._regression, supervised_dataset)
 
-    def predict(self, dataset: Table) -> Table:
+    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first
 
@@ -38,6 +41,8 @@ class ElasticNetRegression:
         ----------
         dataset: Table
             the dataset containing the feature vectors
+        target_name: Optional[str]
+            the name of the target vector, the name of the target column inferred from fit is used by default
 
         Returns
         -------
@@ -49,4 +54,4 @@ class ElasticNetRegression:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._regression, dataset)
+        return safe_ds._util._util_sklearn.predict(self._regression, dataset, target_name if target_name is not None else self.target_name)

--- a/Runtime/safe-ds/safe_ds/regression/_elastic_net_regression.py
+++ b/Runtime/safe-ds/safe_ds/regression/_elastic_net_regression.py
@@ -31,7 +31,9 @@ class ElasticNetRegression:
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        self.target_name = safe_ds._util._util_sklearn.fit(self._regression, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(
+            self._regression, supervised_dataset
+        )
 
     def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
@@ -54,4 +56,8 @@ class ElasticNetRegression:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._regression, dataset, target_name if target_name is not None else self.target_name)
+        return safe_ds._util._util_sklearn.predict(
+            self._regression,
+            dataset,
+            target_name if target_name is not None else self.target_name,
+        )

--- a/Runtime/safe-ds/safe_ds/regression/_gradient_boosting_regression.py
+++ b/Runtime/safe-ds/safe_ds/regression/_gradient_boosting_regression.py
@@ -1,9 +1,12 @@
+from typing import Optional
+
 # noinspection PyProtectedMember
 import safe_ds._util._util_sklearn
 from safe_ds.data import SupervisedDataset, Table
 from sklearn.ensemble import GradientBoostingRegressor
 
 
+# noinspection PyProtectedMember
 class GradientBoosting:
     """
     This class implements gradient boosting regression. It is used as a regression model.
@@ -12,6 +15,7 @@ class GradientBoosting:
 
     def __init__(self) -> None:
         self._regression = GradientBoostingRegressor()
+        self.target_name = ""
 
     def fit(self, supervised_dataset: SupervisedDataset) -> None:
         """
@@ -28,10 +32,10 @@ class GradientBoosting:
         LearningError
             if the supervised dataset contains invalid values or if the training failed.
         """
-        safe_ds._util._util_sklearn.fit(self._regression, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(self._regression, supervised_dataset)
 
     # noinspection PyProtectedMember
-    def predict(self, dataset: Table) -> Table:
+    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first
 
@@ -39,6 +43,8 @@ class GradientBoosting:
         ----------
         dataset: Table
             the dataset containing the feature vectors
+        target_name: Optional[str]
+            the name of the target vector, the name of the target column inferred from fit is used by default
 
         Returns
         -------
@@ -50,4 +56,4 @@ class GradientBoosting:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._regression, dataset)
+        return safe_ds._util._util_sklearn.predict(self._regression, dataset, target_name if target_name is not None else self.target_name)

--- a/Runtime/safe-ds/safe_ds/regression/_gradient_boosting_regression.py
+++ b/Runtime/safe-ds/safe_ds/regression/_gradient_boosting_regression.py
@@ -32,7 +32,9 @@ class GradientBoosting:
         LearningError
             if the supervised dataset contains invalid values or if the training failed.
         """
-        self.target_name = safe_ds._util._util_sklearn.fit(self._regression, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(
+            self._regression, supervised_dataset
+        )
 
     # noinspection PyProtectedMember
     def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
@@ -56,4 +58,8 @@ class GradientBoosting:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._regression, dataset, target_name if target_name is not None else self.target_name)
+        return safe_ds._util._util_sklearn.predict(
+            self._regression,
+            dataset,
+            target_name if target_name is not None else self.target_name,
+        )

--- a/Runtime/safe-ds/safe_ds/regression/_k_nearest_neighbors.py
+++ b/Runtime/safe-ds/safe_ds/regression/_k_nearest_neighbors.py
@@ -35,7 +35,9 @@ class KNearestNeighbors:
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        self.target_name = safe_ds._util._util_sklearn.fit(self._regression, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(
+            self._regression, supervised_dataset
+        )
 
     def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
@@ -58,4 +60,8 @@ class KNearestNeighbors:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._regression, dataset, target_name if target_name is not None else self.target_name)
+        return safe_ds._util._util_sklearn.predict(
+            self._regression,
+            dataset,
+            target_name if target_name is not None else self.target_name,
+        )

--- a/Runtime/safe-ds/safe_ds/regression/_k_nearest_neighbors.py
+++ b/Runtime/safe-ds/safe_ds/regression/_k_nearest_neighbors.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 # noinspection PyProtectedMember
 import safe_ds._util._util_sklearn
 from safe_ds.data import SupervisedDataset, Table
@@ -17,6 +19,7 @@ class KNearestNeighbors:
 
     def __init__(self, n_neighbors: int) -> None:
         self._regression = KNeighborsRegressor(n_neighbors)
+        self.target_name = ""
 
     def fit(self, supervised_dataset: SupervisedDataset) -> None:
         """
@@ -32,9 +35,9 @@ class KNearestNeighbors:
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        safe_ds._util._util_sklearn.fit(self._regression, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(self._regression, supervised_dataset)
 
-    def predict(self, dataset: Table) -> Table:
+    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first
 
@@ -42,6 +45,8 @@ class KNearestNeighbors:
         ----------
         dataset: Table
             the dataset containing the feature vectors
+        target_name: Optional[str]
+            the name of the target vector, the name of the target column inferred from fit is used by default
 
         Returns
         -------
@@ -53,4 +58,4 @@ class KNearestNeighbors:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._regression, dataset)
+        return safe_ds._util._util_sklearn.predict(self._regression, dataset, target_name if target_name is not None else self.target_name)

--- a/Runtime/safe-ds/safe_ds/regression/_lasso_regression.py
+++ b/Runtime/safe-ds/safe_ds/regression/_lasso_regression.py
@@ -31,7 +31,9 @@ class LassoRegression:
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        self.target_name = safe_ds._util._util_sklearn.fit(self._regression, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(
+            self._regression, supervised_dataset
+        )
 
     def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
@@ -54,4 +56,8 @@ class LassoRegression:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._regression, dataset, target_name if target_name is not None else self.target_name)
+        return safe_ds._util._util_sklearn.predict(
+            self._regression,
+            dataset,
+            target_name if target_name is not None else self.target_name,
+        )

--- a/Runtime/safe-ds/safe_ds/regression/_lasso_regression.py
+++ b/Runtime/safe-ds/safe_ds/regression/_lasso_regression.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 # noinspection PyProtectedMember
 import safe_ds._util._util_sklearn
 from safe_ds.data import SupervisedDataset, Table
@@ -13,6 +15,7 @@ class LassoRegression:
 
     def __init__(self) -> None:
         self._regression = sk_Lasso()
+        self.target_name = ""
 
     def fit(self, supervised_dataset: SupervisedDataset) -> None:
         """
@@ -28,9 +31,9 @@ class LassoRegression:
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        safe_ds._util._util_sklearn.fit(self._regression, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(self._regression, supervised_dataset)
 
-    def predict(self, dataset: Table) -> Table:
+    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first
 
@@ -38,6 +41,8 @@ class LassoRegression:
         ----------
         dataset: Table
             the dataset containing the feature vectors
+        target_name: Optional[str]
+            the name of the target vector, the name of the target column inferred from fit is used by default
 
         Returns
         -------
@@ -49,4 +54,4 @@ class LassoRegression:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._regression, dataset)
+        return safe_ds._util._util_sklearn.predict(self._regression, dataset, target_name if target_name is not None else self.target_name)

--- a/Runtime/safe-ds/safe_ds/regression/_linear_regression.py
+++ b/Runtime/safe-ds/safe_ds/regression/_linear_regression.py
@@ -31,7 +31,9 @@ class LinearRegression:
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        self.target_name = safe_ds._util._util_sklearn.fit(self._regression, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(
+            self._regression, supervised_dataset
+        )
 
     def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
@@ -54,4 +56,8 @@ class LinearRegression:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._regression, dataset, target_name if target_name is not None else self.target_name)
+        return safe_ds._util._util_sklearn.predict(
+            self._regression,
+            dataset,
+            target_name if target_name is not None else self.target_name,
+        )

--- a/Runtime/safe-ds/safe_ds/regression/_linear_regression.py
+++ b/Runtime/safe-ds/safe_ds/regression/_linear_regression.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 # noinspection PyProtectedMember
 import safe_ds._util._util_sklearn
 from safe_ds.data import SupervisedDataset, Table
@@ -13,6 +15,7 @@ class LinearRegression:
 
     def __init__(self) -> None:
         self._regression = sk_LinearRegression(n_jobs=-1)
+        self.target_name = ""
 
     def fit(self, supervised_dataset: SupervisedDataset) -> None:
         """
@@ -28,9 +31,9 @@ class LinearRegression:
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        safe_ds._util._util_sklearn.fit(self._regression, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(self._regression, supervised_dataset)
 
-    def predict(self, dataset: Table) -> Table:
+    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first
 
@@ -38,6 +41,8 @@ class LinearRegression:
         ----------
         dataset: Table
             the dataset containing the feature vectors
+        target_name: Optional[str]
+            the name of the target vector, the name of the target column inferred from fit is used by default
 
         Returns
         -------
@@ -49,4 +54,4 @@ class LinearRegression:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._regression, dataset)
+        return safe_ds._util._util_sklearn.predict(self._regression, dataset, target_name if target_name is not None else self.target_name)

--- a/Runtime/safe-ds/safe_ds/regression/_random_forest.py
+++ b/Runtime/safe-ds/safe_ds/regression/_random_forest.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 # noinspection PyProtectedMember
 import safe_ds._util._util_sklearn
 from safe_ds.data import SupervisedDataset, Table
@@ -12,6 +14,7 @@ class RandomForest:
 
     def __init__(self) -> None:
         self._regression = RandomForestRegressor(n_jobs=-1)
+        self.target_name = ""
 
     def fit(self, supervised_dataset: SupervisedDataset) -> None:
         """
@@ -27,9 +30,9 @@ class RandomForest:
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        safe_ds._util._util_sklearn.fit(self._regression, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(self._regression, supervised_dataset)
 
-    def predict(self, dataset: Table) -> Table:
+    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first
 
@@ -37,6 +40,8 @@ class RandomForest:
         ----------
         dataset: Table
             the dataset containing the feature vectors
+        target_name: Optional[str]
+            the name of the target vector, the name of the target column inferred from fit is used by default
 
         Returns
         -------
@@ -48,4 +53,5 @@ class RandomForest:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._regression, dataset)
+        return safe_ds._util._util_sklearn.predict(self._regression, dataset,
+                                                   target_name if target_name is not None else self.target_name)

--- a/Runtime/safe-ds/safe_ds/regression/_random_forest.py
+++ b/Runtime/safe-ds/safe_ds/regression/_random_forest.py
@@ -30,7 +30,9 @@ class RandomForest:
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        self.target_name = safe_ds._util._util_sklearn.fit(self._regression, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(
+            self._regression, supervised_dataset
+        )
 
     def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
@@ -53,5 +55,8 @@ class RandomForest:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._regression, dataset,
-                                                   target_name if target_name is not None else self.target_name)
+        return safe_ds._util._util_sklearn.predict(
+            self._regression,
+            dataset,
+            target_name if target_name is not None else self.target_name,
+        )

--- a/Runtime/safe-ds/safe_ds/regression/_ridge_regression.py
+++ b/Runtime/safe-ds/safe_ds/regression/_ridge_regression.py
@@ -31,7 +31,9 @@ class RidgeRegression:
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        self.target_name = safe_ds._util._util_sklearn.fit(self._regression, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(
+            self._regression, supervised_dataset
+        )
 
     def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
@@ -54,5 +56,8 @@ class RidgeRegression:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._regression, dataset,
-                                                   target_name if target_name is not None else self.target_name)
+        return safe_ds._util._util_sklearn.predict(
+            self._regression,
+            dataset,
+            target_name if target_name is not None else self.target_name,
+        )

--- a/Runtime/safe-ds/safe_ds/regression/_ridge_regression.py
+++ b/Runtime/safe-ds/safe_ds/regression/_ridge_regression.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 # noinspection PyProtectedMember
 import safe_ds._util._util_sklearn
 from safe_ds.data import SupervisedDataset, Table
@@ -13,6 +15,7 @@ class RidgeRegression:
 
     def __init__(self) -> None:
         self._regression = sk_Ridge()
+        self.target_name = ""
 
     def fit(self, supervised_dataset: SupervisedDataset) -> None:
         """
@@ -28,9 +31,9 @@ class RidgeRegression:
         LearningError
             if the supervised dataset contains invalid values or if the training failed
         """
-        safe_ds._util._util_sklearn.fit(self._regression, supervised_dataset)
+        self.target_name = safe_ds._util._util_sklearn.fit(self._regression, supervised_dataset)
 
-    def predict(self, dataset: Table) -> Table:
+    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first
 
@@ -38,6 +41,8 @@ class RidgeRegression:
         ----------
         dataset: Table
             the dataset containing the feature vectors
+        target_name: Optional[str]
+            the name of the target vector, the name of the target column inferred from fit is used by default
 
         Returns
         -------
@@ -49,4 +54,5 @@ class RidgeRegression:
         PredictionError
             if predicting with the given dataset failed
         """
-        return safe_ds._util._util_sklearn.predict(self._regression, dataset)
+        return safe_ds._util._util_sklearn.predict(self._regression, dataset,
+                                                   target_name if target_name is not None else self.target_name)

--- a/Runtime/safe-ds/tests/classification/_ada_boost/test_predict.py
+++ b/Runtime/safe-ds/tests/classification/_ada_boost/test_predict.py
@@ -30,14 +30,3 @@ def test_ada_boost_predict_invalid() -> None:
     ada_boost.fit(supervised_dataset)
     with pytest.raises(PredictionError):
         ada_boost.predict(invalid_supervised_dataset.feature_vectors)
-
-
-def test_ada_boost_predict_invalid_target_predictions() -> None:
-    table = Table.from_csv(
-        "tests/resources/test_ada_boost_invalid_target_predictions.csv"
-    )
-    supervised_dataset = SupervisedDataset(table, "T")
-    ada_boost = AdaBoost()
-    ada_boost.fit(supervised_dataset)
-    with pytest.raises(PredictionError):
-        ada_boost.predict(supervised_dataset.feature_vectors)

--- a/Runtime/safe-ds/tests/classification/_decision_tree/test_predict.py
+++ b/Runtime/safe-ds/tests/classification/_decision_tree/test_predict.py
@@ -30,14 +30,3 @@ def test_decision_tree_predict_invalid() -> None:
     decision_tree.fit(supervised_dataset)
     with pytest.raises(PredictionError):
         decision_tree.predict(invalid_supervised_dataset.feature_vectors)
-
-
-def test_decision_tree_predict_invalid_target_predictions() -> None:
-    table = Table.from_csv(
-        "tests/resources/test_decision_tree_invalid_target_predictions.csv"
-    )
-    supervised_dataset = SupervisedDataset(table, "T")
-    decision_tree = DecisionTree()
-    decision_tree.fit(supervised_dataset)
-    with pytest.raises(PredictionError):
-        decision_tree.predict(supervised_dataset.feature_vectors)

--- a/Runtime/safe-ds/tests/classification/_gradient_boosting/test_predict.py
+++ b/Runtime/safe-ds/tests/classification/_gradient_boosting/test_predict.py
@@ -32,14 +32,3 @@ def test_gradient_boosting_predict_invalid() -> None:
     gradient_boosting.fit(supervised_dataset)
     with pytest.raises(PredictionError):
         gradient_boosting.predict(invalid_supervised_dataset.feature_vectors)
-
-
-def test_gradient_boosting_predict_invalid_target_predictions() -> None:
-    table = Table.from_csv(
-        "tests/resources/test_gradient_boosting_invalid_target_predictions.csv"
-    )
-    supervised_dataset = SupervisedDataset(table, "T")
-    gradient_boosting = GradientBoosting()
-    gradient_boosting.fit(supervised_dataset)
-    with pytest.raises(PredictionError):
-        gradient_boosting.predict(supervised_dataset.feature_vectors)

--- a/Runtime/safe-ds/tests/classification/_k_nearest_neighbors/test_predict.py
+++ b/Runtime/safe-ds/tests/classification/_k_nearest_neighbors/test_predict.py
@@ -32,25 +32,3 @@ def test_k_nearest_neighbors_predict_invalid() -> None:
     k_nearest_neighbors.fit(supervised_dataset)
     with pytest.raises(PredictionError):
         k_nearest_neighbors.predict(invalid_supervised_dataset.feature_vectors)
-
-
-def test_k_nearest_neighbors_predict_invalid_target_predictions() -> None:
-    table = Table.from_csv(
-        "tests/resources/test_k_nearest_neighbors_invalid_target_predictions.csv"
-    )
-    supervised_dataset = SupervisedDataset(table, "T")
-    k_nearest_neighbors = KNearestNeighborsClassifier(2)
-    k_nearest_neighbors.fit(supervised_dataset)
-    with pytest.raises(PredictionError):
-        k_nearest_neighbors.predict(supervised_dataset.feature_vectors)
-
-
-def test_k_nearest_neighbors_predict_invalid_n_neighbors() -> None:
-    table = Table.from_csv(
-        "tests/resources/test_k_nearest_neighbors_invalid_target_predictions.csv"
-    )
-    supervised_dataset = SupervisedDataset(table, "T")
-    k_nearest_neighbors = KNearestNeighborsClassifier(3)
-    k_nearest_neighbors.fit(supervised_dataset)
-    with pytest.raises(PredictionError):
-        k_nearest_neighbors.predict(supervised_dataset.feature_vectors)

--- a/Runtime/safe-ds/tests/classification/_logistic_regression/test_predict.py
+++ b/Runtime/safe-ds/tests/classification/_logistic_regression/test_predict.py
@@ -32,4 +32,3 @@ def test_logistic_regression_predict_invalid() -> None:
     log_regression.fit(supervised_dataset)
     with pytest.raises(PredictionError):
         log_regression.predict(invalid_supervised_dataset.feature_vectors)
-

--- a/Runtime/safe-ds/tests/classification/_logistic_regression/test_predict.py
+++ b/Runtime/safe-ds/tests/classification/_logistic_regression/test_predict.py
@@ -33,13 +33,3 @@ def test_logistic_regression_predict_invalid() -> None:
     with pytest.raises(PredictionError):
         log_regression.predict(invalid_supervised_dataset.feature_vectors)
 
-
-def test_logistic_regression_predict_invalid_target_predictions() -> None:
-    table = Table.from_csv(
-        "tests/resources/test_logistic_regression_invalid_target_predictions.csv"
-    )
-    supervised_dataset = SupervisedDataset(table, "T")
-    log_regression = LogisticRegression()
-    log_regression.fit(supervised_dataset)
-    with pytest.raises(PredictionError):
-        log_regression.predict(supervised_dataset.feature_vectors)

--- a/Runtime/safe-ds/tests/classification/_random_forest/test_predict.py
+++ b/Runtime/safe-ds/tests/classification/_random_forest/test_predict.py
@@ -30,14 +30,3 @@ def test_random_forest_predict_invalid() -> None:
     random_forest.fit(supervised_dataset)
     with pytest.raises(PredictionError):
         random_forest.predict(invalid_supervised_dataset.feature_vectors)
-
-
-def test_random_forest_predict_invalid_target_predictions() -> None:
-    table = Table.from_csv(
-        "tests/resources/test_random_forest_invalid_target_predictions.csv"
-    )
-    supervised_dataset = SupervisedDataset(table, "T")
-    random_forest = RandomForestClassifier()
-    random_forest.fit(supervised_dataset)
-    with pytest.raises(PredictionError):
-        random_forest.predict(supervised_dataset.feature_vectors)

--- a/Runtime/safe-ds/tests/data/_column/test_get_unique_values.py
+++ b/Runtime/safe-ds/tests/data/_column/test_get_unique_values.py
@@ -1,0 +1,17 @@
+import typing
+
+import pytest
+from safe_ds.data import Column
+
+
+@pytest.mark.parametrize(
+    "values, unique_values",
+    [([1, 1, 2, 3], [1, 2, 3]), (["a", "b", "b", "c"], ["a", "b", "c"]), ([], [])],
+)
+def test_get_unique_values(
+    values: list[typing.Any], unique_values: list[typing.Any]
+) -> None:
+    column: Column = Column(values, "")
+    extracted_unique_values: list[typing.Any] = column.get_unique_values()
+
+    assert extracted_unique_values == unique_values

--- a/Runtime/safe-ds/tests/regression/_ada_boost/test_predict.py
+++ b/Runtime/safe-ds/tests/regression/_ada_boost/test_predict.py
@@ -30,14 +30,3 @@ def test_ada_boost_predict_invalid() -> None:
     ada_boost.fit(supervised_dataset)
     with pytest.raises(PredictionError):
         ada_boost.predict(invalid_supervised_dataset.feature_vectors)
-
-
-def test_ada_boost_predict_invalid_target_predictions() -> None:
-    table = Table.from_csv(
-        "tests/resources/test_ada_boost_invalid_target_predictions.csv"
-    )
-    supervised_dataset = SupervisedDataset(table, "T")
-    ada_boost = AdaBoost()
-    ada_boost.fit(supervised_dataset)
-    with pytest.raises(PredictionError):
-        ada_boost.predict(supervised_dataset.feature_vectors)

--- a/Runtime/safe-ds/tests/regression/_decision_tree/test_predict.py
+++ b/Runtime/safe-ds/tests/regression/_decision_tree/test_predict.py
@@ -30,14 +30,3 @@ def test_decision_tree_predict_invalid() -> None:
     decision_tree.fit(supervised_dataset)
     with pytest.raises(PredictionError):
         decision_tree.predict(invalid_supervised_dataset.feature_vectors)
-
-
-def test_decision_tree_predict_invalid_target_predictions() -> None:
-    table = Table.from_csv(
-        "tests/resources/test_decision_tree_invalid_target_predictions.csv"
-    )
-    supervised_dataset = SupervisedDataset(table, "T")
-    decision_tree = DecisionTree()
-    decision_tree.fit(supervised_dataset)
-    with pytest.raises(PredictionError):
-        decision_tree.predict(supervised_dataset.feature_vectors)

--- a/Runtime/safe-ds/tests/regression/_elastic_net/test_predict.py
+++ b/Runtime/safe-ds/tests/regression/_elastic_net/test_predict.py
@@ -32,14 +32,3 @@ def test_elastic_net_regression_predict_invalid() -> None:
     en_regression.fit(supervised_dataset)
     with pytest.raises(PredictionError):
         en_regression.predict(invalid_supervised_dataset.feature_vectors)
-
-
-def test_elastic_net_regression_predict_invalid_target_predictions() -> None:
-    table = Table.from_csv(
-        "tests/resources/test_elastic_net_regression_invalid_target_predictions.csv"
-    )
-    supervised_dataset = SupervisedDataset(table, "T")
-    en_regression = ElasticNetRegression()
-    en_regression.fit(supervised_dataset)
-    with pytest.raises(PredictionError):
-        en_regression.predict(supervised_dataset.feature_vectors)

--- a/Runtime/safe-ds/tests/regression/_gradient_boosting_regression/test_predict.py
+++ b/Runtime/safe-ds/tests/regression/_gradient_boosting_regression/test_predict.py
@@ -32,14 +32,3 @@ def test_gradient_boosting_predict_invalid() -> None:
     gradient_boosting_regression.fit(supervised_dataset)
     with pytest.raises(PredictionError):
         gradient_boosting_regression.predict(invalid_supervised_dataset.feature_vectors)
-
-
-def test_gradient_boosting_predict_invalid_target_predictions() -> None:
-    table = Table.from_csv(
-        "tests/resources/test_gradient_boosting_invalid_target_predictions.csv"
-    )
-    supervised_dataset = SupervisedDataset(table, "T")
-    gradient_boosting_regression = GradientBoosting()
-    gradient_boosting_regression.fit(supervised_dataset)
-    with pytest.raises(PredictionError):
-        gradient_boosting_regression.predict(supervised_dataset.feature_vectors)

--- a/Runtime/safe-ds/tests/regression/_k_nearest_neighbors/test_predict.py
+++ b/Runtime/safe-ds/tests/regression/_k_nearest_neighbors/test_predict.py
@@ -32,25 +32,3 @@ def test_k_nearest_neighbors_predict_invalid() -> None:
     k_nearest_neighbors.fit(supervised_dataset)
     with pytest.raises(PredictionError):
         k_nearest_neighbors.predict(invalid_supervised_dataset.feature_vectors)
-
-
-def test_k_nearest_neighbors_predict_invalid_target_predictions() -> None:
-    table = Table.from_csv(
-        "tests/resources/test_k_nearest_neighbors_invalid_target_predictions.csv"
-    )
-    supervised_dataset = SupervisedDataset(table, "T")
-    k_nearest_neighbors = KNearestNeighborsRegressor(2)
-    k_nearest_neighbors.fit(supervised_dataset)
-    with pytest.raises(PredictionError):
-        k_nearest_neighbors.predict(supervised_dataset.feature_vectors)
-
-
-def test_k_nearest_neighbors_predict_invalid_n_neighbors() -> None:
-    table = Table.from_csv(
-        "tests/resources/test_k_nearest_neighbors_invalid_target_predictions.csv"
-    )
-    supervised_dataset = SupervisedDataset(table, "T")
-    k_nearest_neighbors = KNearestNeighborsRegressor(3)
-    k_nearest_neighbors.fit(supervised_dataset)
-    with pytest.raises(PredictionError):
-        k_nearest_neighbors.predict(supervised_dataset.feature_vectors)

--- a/Runtime/safe-ds/tests/regression/_lasso_regression/test_predict.py
+++ b/Runtime/safe-ds/tests/regression/_lasso_regression/test_predict.py
@@ -30,14 +30,3 @@ def test_lasso_regression_predict_invalid() -> None:
     lasso_regression.fit(supervised_dataset)
     with pytest.raises(PredictionError):
         lasso_regression.predict(invalid_supervised_dataset.feature_vectors)
-
-
-def test_lasso_regression_predict_invalid_target_predictions() -> None:
-    table = Table.from_csv(
-        "tests/resources/test_lasso_regression_invalid_target_predictions.csv"
-    )
-    supervised_dataset = SupervisedDataset(table, "T")
-    lasso_regression = LassoRegression()
-    lasso_regression.fit(supervised_dataset)
-    with pytest.raises(PredictionError):
-        lasso_regression.predict(supervised_dataset.feature_vectors)

--- a/Runtime/safe-ds/tests/regression/_linear_regression/test_predict.py
+++ b/Runtime/safe-ds/tests/regression/_linear_regression/test_predict.py
@@ -30,14 +30,3 @@ def test_linear_regression_predict_invalid() -> None:
     linear_regression.fit(supervised_dataset)
     with pytest.raises(PredictionError):
         linear_regression.predict(invalid_supervised_dataset.feature_vectors)
-
-
-def test_linear_regression_predict_invalid_target_predictions() -> None:
-    table = Table.from_csv(
-        "tests/resources/test_linear_regression_invalid_target_predictions.csv"
-    )
-    supervised_dataset = SupervisedDataset(table, "T")
-    linear_regression = LinearRegression()
-    linear_regression.fit(supervised_dataset)
-    with pytest.raises(PredictionError):
-        linear_regression.predict(supervised_dataset.feature_vectors)

--- a/Runtime/safe-ds/tests/regression/_random_forest/test_predict.py
+++ b/Runtime/safe-ds/tests/regression/_random_forest/test_predict.py
@@ -30,14 +30,3 @@ def test_random_forest_predict_invalid() -> None:
     random_forest.fit(supervised_dataset)
     with pytest.raises(PredictionError):
         random_forest.predict(invalid_supervised_dataset.feature_vectors)
-
-
-def test_random_forest_predict_invalid_target_predictions() -> None:
-    table = Table.from_csv(
-        "tests/resources/test_random_forest_invalid_target_predictions.csv"
-    )
-    supervised_dataset = SupervisedDataset(table, "T")
-    random_forest = RandomForestRegressor()
-    random_forest.fit(supervised_dataset)
-    with pytest.raises(PredictionError):
-        random_forest.predict(supervised_dataset.feature_vectors)

--- a/Runtime/safe-ds/tests/regression/_ridge_regression/test_predict.py
+++ b/Runtime/safe-ds/tests/regression/_ridge_regression/test_predict.py
@@ -30,14 +30,3 @@ def test_ridge_regression_predict_invalid() -> None:
     ridge_regression.fit(supervised_dataset)
     with pytest.raises(PredictionError):
         ridge_regression.predict(invalid_supervised_dataset.feature_vectors)
-
-
-def test_ridge_regression_predict_invalid_target_predictions() -> None:
-    table = Table.from_csv(
-        "tests/resources/test_ridge_regression_invalid_target_predictions.csv"
-    )
-    supervised_dataset = SupervisedDataset(table, "T")
-    ridge_regression = RidgeRegression()
-    ridge_regression.fit(supervised_dataset)
-    with pytest.raises(PredictionError):
-        ridge_regression.predict(supervised_dataset.feature_vectors)

--- a/Runtime/safe-ds/tests/resources/test_ada_boost_invalid_target_predictions.csv
+++ b/Runtime/safe-ds/tests/resources/test_ada_boost_invalid_target_predictions.csv
@@ -1,3 +1,0 @@
-A,B,target_predictions,T
-1,2,3,0
-4,5,6,1

--- a/Runtime/safe-ds/tests/resources/test_decision_tree_invalid_target_predictions.csv
+++ b/Runtime/safe-ds/tests/resources/test_decision_tree_invalid_target_predictions.csv
@@ -1,3 +1,0 @@
-A,B,target_predictions,T
-1,2,3,0
-4,5,6,1

--- a/Runtime/safe-ds/tests/resources/test_elastic_net_regression_invalid_target_predictions.csv
+++ b/Runtime/safe-ds/tests/resources/test_elastic_net_regression_invalid_target_predictions.csv
@@ -1,3 +1,0 @@
-A,B,target_predictions,T
-1,2,3,0
-4,5,6,1

--- a/Runtime/safe-ds/tests/resources/test_gradient_boosting_invalid_target_predictions.csv
+++ b/Runtime/safe-ds/tests/resources/test_gradient_boosting_invalid_target_predictions.csv
@@ -1,3 +1,0 @@
-A,B,target_predictions,T
-1,2,3,0
-4,5,6,1

--- a/Runtime/safe-ds/tests/resources/test_k_nearest_neighbors_invalid_target_predictions.csv
+++ b/Runtime/safe-ds/tests/resources/test_k_nearest_neighbors_invalid_target_predictions.csv
@@ -1,3 +1,0 @@
-A,B,target_predictions,T
-1,2,3,0
-4,5,6,1

--- a/Runtime/safe-ds/tests/resources/test_lasso_regression_invalid_target_predictions.csv
+++ b/Runtime/safe-ds/tests/resources/test_lasso_regression_invalid_target_predictions.csv
@@ -1,3 +1,0 @@
-A,B,target_predictions,T
-1,2,3,0
-4,5,6,1

--- a/Runtime/safe-ds/tests/resources/test_linear_regression_invalid_target_predictions.csv
+++ b/Runtime/safe-ds/tests/resources/test_linear_regression_invalid_target_predictions.csv
@@ -1,3 +1,0 @@
-A,B,target_predictions,T
-1,2,3,0
-4,5,6,1

--- a/Runtime/safe-ds/tests/resources/test_logistic_regression_invalid_target_predictions.csv
+++ b/Runtime/safe-ds/tests/resources/test_logistic_regression_invalid_target_predictions.csv
@@ -1,3 +1,0 @@
-A,B,target_predictions,T
-1,2,3,0
-4,5,6,1

--- a/Runtime/safe-ds/tests/resources/test_random_forest_invalid_target_predictions.csv
+++ b/Runtime/safe-ds/tests/resources/test_random_forest_invalid_target_predictions.csv
@@ -1,3 +1,0 @@
-A,B,target_predictions,T
-1,2,3,0
-4,5,6,1

--- a/Runtime/safe-ds/tests/resources/test_ridge_regression_invalid_target_predictions.csv
+++ b/Runtime/safe-ds/tests/resources/test_ridge_regression_invalid_target_predictions.csv
@@ -1,3 +1,0 @@
-A,B,target_predictions,T
-1,2,3,0
-4,5,6,1


### PR DESCRIPTION
Closes #314 

### Summary of Changes

Target column names are no longer hardcoded in classifiers and regression models. Instead, they are inferred from the supervised dataset the model was trained on. Optionally the user can overwrite the target name in the predict method.

Some tests which tested the hardcoded behavior are deleted.