### PR TITLE
feat: Added method sort_columns in Table and changed equals to not care about order

### DIFF
--- a/Runtime/safe-ds/safe_ds/data/_table.py
+++ b/Runtime/safe-ds/safe_ds/data/_table.py
@@ -620,7 +620,10 @@ class Table:
 
     def sort_columns(
         self,
-        query: Callable[[Column, Column], int] = lambda col1, col2: (col1.name > col2.name) - (col1.name < col2.name),
+        query: Callable[[Column, Column], int] = lambda col1, col2: (
+            col1.name > col2.name
+        )
+        - (col1.name < col2.name),
     ) -> Table:
         """
         Sort a Table with the given lambda function.
@@ -651,10 +654,7 @@ class Table:
             return True
         table1 = self.sort_columns()
         table2 = other.sort_columns()
-        return (
-            table1._data.equals(table2._data)
-            and table1.schema == table2.schema
-        )
+        return table1._data.equals(table2._data) and table1.schema == table2.schema
 
     def __hash__(self) -> int:
         return hash(self._data)

--- a/Runtime/safe-ds/safe_ds/data/_table.py
+++ b/Runtime/safe-ds/safe_ds/data/_table.py
@@ -206,7 +206,8 @@ class Table:
         data_to_csv.to_csv(path_to_file, index=False)
 
     def rename_column(self, old_name: str, new_name: str) -> Table:
-        """Rename a single column by providing the previous name and the future name of it.
+        """
+        Rename a single column by providing the previous name and the future name of it.
 
         Parameters
         ----------
@@ -239,7 +240,8 @@ class Table:
         return Table(new_df.rename(columns={old_name: new_name}))
 
     def get_column(self, column_name: str) -> Column:
-        """Returns a new instance of Column with the data of the described column of the Table.
+        """
+        Returns a new instance of Column with the data of the described column of the Table.
 
         Parameters
         ----------
@@ -267,7 +269,8 @@ class Table:
         raise UnknownColumnNameError([column_name])
 
     def drop_columns(self, column_names: list[str]) -> Table:
-        """Returns a Table without the given columns
+        """
+        Returns a Table without the given columns
 
         Parameters
         ----------
@@ -300,7 +303,8 @@ class Table:
         return Table(transformed_data)
 
     def keep_columns(self, column_names: list[str]) -> Table:
-        """Returns a Table with exactly the given columns
+        """
+        Returns a Table with exactly the given columns
 
         Parameters
         ----------
@@ -346,7 +350,8 @@ class Table:
         ]
 
     def filter_rows(self, query: Callable[[Row], bool]) -> Table:
-        """Returns a Table with rows filtered by applied lambda function
+        """
+        Returns a Table with rows filtered by applied lambda function
 
         Parameters
         ----------
@@ -560,7 +565,8 @@ class Table:
 
     def sort_columns(self, query: Callable[[Column, Column], bool] = lambda col1, col2: col1.name > col2.name) -> Table:
         """
-        Sort a Table with the given lambda function
+        Sort a Table with the given lambda function.
+        If no function is given the columns will be sorted alphabetically.
         This function uses bubble sort.
         The query should return:
             TRUE if both columns should be switched

--- a/Runtime/safe-ds/safe_ds/data/_table.py
+++ b/Runtime/safe-ds/safe_ds/data/_table.py
@@ -558,12 +558,39 @@ class Table:
                 cols.append(self.get_column(column_name))
         return cols
 
+    def sort_columns(self, query: Callable[[Column, Column], bool] = lambda col1, col2: col1.name > col2.name) -> Table:
+        """
+        Sort a Table with the given lambda function
+        This function uses bubble sort.
+        The query should return:
+            TRUE if both columns should be switched
+            FALSE if the columns should not be switched
+
+        Parameters
+        ----------
+        query: a lambda function
+            a lambda function that is used to sort the columns
+
+        Returns
+        -------
+        new_table: Table
+            a new table with the sorted columns
+        """
+        columns = self.to_columns()
+        for iteration in range(len(columns) - 1):
+            for element in range(0, len(columns) - iteration - 1):
+                if query(columns[element], columns[element + 1]):
+                    c = columns[element]
+                    columns[element] = columns[element + 1]
+                    columns[element + 1] = c
+        return Table.from_columns(columns)
+
     def __eq__(self, other: typing.Any) -> bool:
         if not isinstance(other, Table):
             return NotImplemented
         if self is other:
             return True
-        return self._data.equals(other._data) and self.schema == other.schema
+        return self.sort_columns()._data.equals(other.sort_columns()._data) and self.sort_columns().schema == other.sort_columns().schema
 
     def __hash__(self) -> int:
         return hash(self._data)

--- a/Runtime/safe-ds/safe_ds/data/_table.py
+++ b/Runtime/safe-ds/safe_ds/data/_table.py
@@ -271,7 +271,7 @@ class Table:
 
     def drop_columns(self, column_names: list[str]) -> Table:
         """
-        Returns a Table without the given columns
+        Returns a table without the given columns
 
         Parameters
         ----------
@@ -305,7 +305,7 @@ class Table:
 
     def keep_columns(self, column_names: list[str]) -> Table:
         """
-        Returns a Table with exactly the given columns
+        Returns a table with exactly the given columns
 
         Parameters
         ----------
@@ -352,7 +352,7 @@ class Table:
 
     def filter_rows(self, query: Callable[[Row], bool]) -> Table:
         """
-        Returns a Table with rows filtered by applied lambda function
+        Returns a table with rows filtered by applied lambda function
 
         Parameters
         ----------

--- a/Runtime/safe-ds/safe_ds/data/_table.py
+++ b/Runtime/safe-ds/safe_ds/data/_table.py
@@ -242,7 +242,7 @@ class Table:
 
     def get_column(self, column_name: str) -> Column:
         """
-        Returns a new instance of column with the data of the described column of the Table.
+        Returns a new instance of column with the data of the described column of the table.
 
         Parameters
         ----------

--- a/Runtime/safe-ds/safe_ds/data/_table.py
+++ b/Runtime/safe-ds/safe_ds/data/_table.py
@@ -242,7 +242,7 @@ class Table:
 
     def get_column(self, column_name: str) -> Column:
         """
-        Returns a new instance of Column with the data of the described column of the Table.
+        Returns a new instance of column with the data of the described column of the Table.
 
         Parameters
         ----------
@@ -626,12 +626,13 @@ class Table:
         - (col1.name < col2.name),
     ) -> Table:
         """
-        Sort a Table with the given lambda function.
+        Sort a table with the given lambda function.
         If no function is given the columns will be sorted alphabetically.
-        This function uses bubble sort.
+        This function uses the default python sort algorithm.
         The query should return:
-            TRUE if both columns should be switched
-            FALSE if the columns should not be switched
+            0, if both columns are equal
+            < 0, if the first column should be ordered after the second column
+            > 0, if the first column should be ordered before the second column
 
         Parameters
         ----------

--- a/Runtime/safe-ds/safe_ds/data/_table.py
+++ b/Runtime/safe-ds/safe_ds/data/_table.py
@@ -617,7 +617,11 @@ class Table:
                 cols.append(self.get_column(column_name))
         return cols
 
-    def sort_columns(self, query: Callable[[Column, Column], bool] = lambda col1, col2: col1.name > col2.name) -> Table:
+    def sort_columns(
+        self,
+        query: Callable[[Column, Column], bool] = lambda col1, col2: col1.name
+        > col2.name,
+    ) -> Table:
         """
         Sort a Table with the given lambda function.
         If no function is given the columns will be sorted alphabetically.
@@ -650,7 +654,10 @@ class Table:
             return NotImplemented
         if self is other:
             return True
-        return self.sort_columns()._data.equals(other.sort_columns()._data) and self.sort_columns().schema == other.sort_columns().schema
+        return (
+            self.sort_columns()._data.equals(other.sort_columns()._data)
+            and self.sort_columns().schema == other.sort_columns().schema
+        )
 
     def __hash__(self) -> int:
         return hash(self._data)

--- a/Runtime/safe-ds/tests/data/_table/test_sort_columns.py
+++ b/Runtime/safe-ds/tests/data/_table/test_sort_columns.py
@@ -7,7 +7,16 @@ from safe_ds.data import Column, Table
 
 @pytest.mark.parametrize(
     "query, col1, col2, col3, col4",
-    [(None, 0, 1, 2, 3), (lambda col1, col2: (col1.name < col2.name) - (col1.name > col2.name), 3, 2, 1, 0)],
+    [
+        (None, 0, 1, 2, 3),
+        (
+            lambda col1, col2: (col1.name < col2.name) - (col1.name > col2.name),
+            3,
+            2,
+            1,
+            0,
+        ),
+    ],
 )
 def test_sort_columns_valid(
     query: Callable[[Column, Column], int], col1: int, col2: int, col3: int, col4: int

--- a/Runtime/safe-ds/tests/data/_table/test_sort_columns.py
+++ b/Runtime/safe-ds/tests/data/_table/test_sort_columns.py
@@ -1,0 +1,26 @@
+from typing import Callable
+
+import pandas as pd
+import pytest
+
+from safe_ds.data import Table, Column
+
+
+@pytest.mark.parametrize(
+    "query, col1, col2, col3, col4",
+    [(None, 0, 1, 2, 3), (lambda col1, col2: col1.name < col2.name, 3, 2, 1, 0)],
+)
+def test_sort_columns_valid(query: Callable[[Column, Column], bool], col1: int, col2: int, col3: int, col4: int) -> None:
+    columns = [Column(pd.Series(data=["A", "B", "C", "A", "D"]), "col1"), Column(pd.Series(data=["Test1", "Test1", "Test3", "Test1", "Test4"]), "col2"), Column(pd.Series(data=[1,2,3,4,5]), "col3"), Column(pd.Series(data=[2,3,1,4,6]), "col4")]
+    table1 = Table(pd.DataFrame(data={"col2": ["Test1", "Test1", "Test3", "Test1", "Test4"], "col3": [1,2,3,4,5], "col4": [2,3,1,4,6], "col1": ["A", "B", "C", "A", "D"]}))
+    if query is not None:
+        table_sorted = table1.sort_columns(query)
+    else:
+        table_sorted = table1.sort_columns()
+    table_sorted_columns = table_sorted.to_columns()
+    assert table_sorted_columns[0] == columns[col1]
+    assert table_sorted_columns[1] == columns[col2]
+    assert table_sorted_columns[2] == columns[col3]
+    assert table_sorted_columns[3] == columns[col4]
+    assert table_sorted.count_columns() == 4
+    assert table_sorted.count_rows() == table1.count_rows()

--- a/Runtime/safe-ds/tests/data/_table/test_sort_columns.py
+++ b/Runtime/safe-ds/tests/data/_table/test_sort_columns.py
@@ -7,10 +7,10 @@ from safe_ds.data import Column, Table
 
 @pytest.mark.parametrize(
     "query, col1, col2, col3, col4",
-    [(None, 0, 1, 2, 3), (lambda col1, col2: col1.name < col2.name, 3, 2, 1, 0)],
+    [(None, 0, 1, 2, 3), (lambda col1, col2: (col1.name < col2.name) - (col1.name > col2.name), 3, 2, 1, 0)],
 )
 def test_sort_columns_valid(
-    query: Callable[[Column, Column], bool], col1: int, col2: int, col3: int, col4: int
+    query: Callable[[Column, Column], int], col1: int, col2: int, col3: int, col4: int
 ) -> None:
     columns = [
         Column(pd.Series(data=["A", "B", "C", "A", "D"]), "col1"),

--- a/Runtime/safe-ds/tests/data/_table/test_sort_columns.py
+++ b/Runtime/safe-ds/tests/data/_table/test_sort_columns.py
@@ -2,17 +2,32 @@ from typing import Callable
 
 import pandas as pd
 import pytest
-
-from safe_ds.data import Table, Column
+from safe_ds.data import Column, Table
 
 
 @pytest.mark.parametrize(
     "query, col1, col2, col3, col4",
     [(None, 0, 1, 2, 3), (lambda col1, col2: col1.name < col2.name, 3, 2, 1, 0)],
 )
-def test_sort_columns_valid(query: Callable[[Column, Column], bool], col1: int, col2: int, col3: int, col4: int) -> None:
-    columns = [Column(pd.Series(data=["A", "B", "C", "A", "D"]), "col1"), Column(pd.Series(data=["Test1", "Test1", "Test3", "Test1", "Test4"]), "col2"), Column(pd.Series(data=[1,2,3,4,5]), "col3"), Column(pd.Series(data=[2,3,1,4,6]), "col4")]
-    table1 = Table(pd.DataFrame(data={"col2": ["Test1", "Test1", "Test3", "Test1", "Test4"], "col3": [1,2,3,4,5], "col4": [2,3,1,4,6], "col1": ["A", "B", "C", "A", "D"]}))
+def test_sort_columns_valid(
+    query: Callable[[Column, Column], bool], col1: int, col2: int, col3: int, col4: int
+) -> None:
+    columns = [
+        Column(pd.Series(data=["A", "B", "C", "A", "D"]), "col1"),
+        Column(pd.Series(data=["Test1", "Test1", "Test3", "Test1", "Test4"]), "col2"),
+        Column(pd.Series(data=[1, 2, 3, 4, 5]), "col3"),
+        Column(pd.Series(data=[2, 3, 1, 4, 6]), "col4"),
+    ]
+    table1 = Table(
+        pd.DataFrame(
+            data={
+                "col2": ["Test1", "Test1", "Test3", "Test1", "Test4"],
+                "col3": [1, 2, 3, 4, 5],
+                "col4": [2, 3, 1, 4, 6],
+                "col1": ["A", "B", "C", "A", "D"],
+            }
+        )
+    )
     if query is not None:
         table_sorted = table1.sort_columns(query)
     else:


### PR DESCRIPTION
Closes #305 .

### Summary of Changes

Added method sort_columns in Table and changed equals to not care about order of columns. The sort_columns method by default sorts after alphabetically order which can be changed by porividing a lambda-function as parameter.