### PR TITLE
docs: upload documentation to readthedocs.org

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,10 @@ updates:
 
   # Runtime
   - package-ecosystem: 'pip'
+    directory: '/docs'
+    schedule:
+      interval: 'monthly'
+  - package-ecosystem: 'pip'
     directory: '/Runtime/safe-ds'
     schedule:
       interval: 'monthly'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Safe-DS
 
 [![Main](https://github.com/lars-reimann/Safe-DS/actions/workflows/main.yml/badge.svg)](https://github.com/lars-reimann/Safe-DS/actions/workflows/main.yml)
+[![Documentation Status](https://readthedocs.org/projects/safe-ds/badge/?version=latest)](https://safe-ds.readthedocs.io/en/latest/?badge=latest)
 
 Safely develop Data Science programs with a statically checked [DSL][dsl] or call our user-friendly [standard library][stdlib] (WIP) directly from Python.
 

--- a/docs/Stdlib/python/column.md
+++ b/docs/Stdlib/python/column.md
@@ -1,0 +1,1 @@
+::: safe_ds.data.Column

--- a/docs/Stdlib/python/row.md
+++ b/docs/Stdlib/python/row.md
@@ -1,0 +1,1 @@
+::: safe_ds.data.Row

--- a/docs/Stdlib/python/table.md
+++ b/docs/Stdlib/python/table.md
@@ -1,0 +1,1 @@
+::: safe_ds.data.Table

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
-mkdocs=1.4.2
-mkdocstrings=0.20.0
-mkdocstrings-python=0.8.3
-mkdocs-autorefs=0.4.1
-mkdocs-material=9.0.6
+mkdocs==1.4.2
+mkdocstrings==0.20.0
+mkdocstrings-python==0.8.3
+mkdocs-autorefs==0.4.1
+mkdocs-material==9.0.6

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+mkdocs=1.4.2
+mkdocstrings=0.20.0
+mkdocstrings-python=0.8.3
+mkdocs-autorefs=0.4.1
+mkdocs-material=9.0.6

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,31 @@
+site_name: Safe-DS
+
+theme:
+  name: material
+
+plugins:
+  - mkdocstrings:
+      handlers:
+        python:
+          paths:
+            - Runtime/safe-ds
+  - autorefs
+  - search
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+
+nav:
+  - Home: README.md
+  - DSL:
+      - Language: DSL/README.md
+      - Standard Library: Stdlib/API/README.md
+  - Python Library:
+      - Stdlib/python/table.md
+      - Stdlib/python/column.md
+      - Stdlib/python/row.md
+  - Developer Guide: Development/README.md

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+mkdocs:
+  configuration: mkdocs.yml
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: '3.10'
 
 mkdocs:
   configuration: mkdocs.yml


### PR DESCRIPTION
Closes #315.

### Summary of Changes

Upload our existing documentation and some auto-generate documentation about the Python library to [readthedocs.org](https://readthedocs.org). We can later enhance the documentation, this PR just establishes the necessary infrastructure.
