### PR TITLE
docs: fix various issues wrt. mkdocs and readthedocs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,7 @@ insert_final_newline = true
 indent_size = 2
 
 [*.{kt,kts}]
-ktlint_disabled_rules = filename
+ktlint_standard_filename = disabled
+kltint_experimental_property-naming = disabled
 ij_kotlin_allow_trailing_comma = true
 ij_kotlin_allow_trailing_comma_on_call_site = true

--- a/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/stdlibDocumentation/DocumentationGenerator.kt
+++ b/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/stdlibDocumentation/DocumentationGenerator.kt
@@ -177,7 +177,7 @@ private fun createAnnotationDocumentation(annotation: SdsAnnotation) = buildStri
     }
 
     // Targets
-    appendLine("\n**Valid targets:**")
+    appendLine("\n**Valid targets:**\n")
     val validTargets = annotation
         .validTargets()
         .sortedBy { it.name }
@@ -233,7 +233,7 @@ private fun createClassDocumentation(`class`: SdsClass, nestingLevel: Int): Stri
 
     // Attributes
     if (attributes.isNotEmpty()) {
-        appendLine("**Attributes:**")
+        appendLine("**Attributes:**\n")
         attributes.forEach {
             append(createAttributeDocumentation(it))
         }
@@ -262,7 +262,7 @@ private fun createConstructorDocumentation(`class`: SdsClass) = buildString {
     } else if (`class`.parametersOrEmpty().isEmpty()) {
         appendLine("**Constructor parameters:** _None expected._")
     } else {
-        appendLine("**Constructor parameters:**")
+        appendLine("**Constructor parameters:**\n")
         `class`.parametersOrEmpty().forEach {
             appendLine(createParameterDocumentation(it))
         }
@@ -329,7 +329,7 @@ private fun createParametersDocumentation(parameters: List<SdsParameter>) = buil
     if (parameters.isEmpty()) {
         appendLine("**Parameters:** _None expected._")
     } else {
-        appendLine("**Parameters:**")
+        appendLine("**Parameters:**\n")
         parameters.forEach {
             appendLine(createParameterDocumentation(it))
         }
@@ -365,7 +365,7 @@ private fun createResultsDocumentation(result: List<SdsResult>) = buildString {
     if (result.isEmpty()) {
         appendLine("**Results:** _None returned._")
     } else {
-        appendLine("**Results:**")
+        appendLine("**Results:**\n")
         result.forEach {
             appendLine(createResultDocumentation(it))
         }

--- a/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/stdlibDocumentation/DocumentationGenerator.kt
+++ b/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/stdlibDocumentation/DocumentationGenerator.kt
@@ -72,7 +72,7 @@ private fun createReadme(outputDirectory: Path, packagesToDeclarations: Map<Stri
             |
             |$autogenWarning
             |
-        """.trimMargin()
+        """.trimMargin(),
     )
 }
 
@@ -90,7 +90,7 @@ private fun createPackageFile(outputDirectory: Path, packageName: String, global
 
 private fun createPackageDocumentation(
     packageName: String,
-    globalDeclarations: List<EObject>
+    globalDeclarations: List<EObject>,
 ) = buildString {
     val classes = globalDeclarations.filterIsInstance<SdsClass>().sortedBy { it.name }
     val globalFunctions = globalDeclarations.filterIsInstance<SdsFunction>().sortedBy { it.name }
@@ -133,7 +133,6 @@ private fun createPackageDocumentation(
 }
 
 private fun createAnnotationDocumentation(annotation: SdsAnnotation) = buildString {
-
     // Heading
     appendLine("## <a name=\"annotation-${annotation.name}\"></a>Annotation `${annotation.name}`")
 
@@ -157,7 +156,6 @@ private fun createAnnotationDocumentation(annotation: SdsAnnotation) = buildStri
 }
 
 private fun createAttributeDocumentation(attribute: SdsAttribute) = buildString {
-
     // Remember description before annotation calls are removed
     val description = attribute.descriptionOrAltText()
 
@@ -258,7 +256,6 @@ private fun createEnumDocumentation(enum: SdsEnum, nestingLevel: Int) = buildStr
 }
 
 private fun createEnumVariantDocumentation(enumVariant: SdsEnumVariant, nestingLevel: Int) = buildString {
-
     // Heading
     appendLine("${heading(nestingLevel)} Enum Variant `${enumVariant.name}`")
 
@@ -274,7 +271,6 @@ private fun SdsAbstractDeclaration.descriptionOrAltText(): String {
 }
 
 private fun createFunctionDocumentation(function: SdsFunction, nestingLevel: Int, isGlobalFunction: Boolean) = buildString {
-
     // Heading
     if (isGlobalFunction) {
         appendLine("## <a name=\"global-function-${function.name}\"></a>Global Function `${function.name}`")
@@ -306,7 +302,6 @@ private fun createParametersDocumentation(parameters: List<SdsParameter>) = buil
 }
 
 private fun createParameterDocumentation(parameter: SdsParameter) = buildString {
-
     // Remember description before annotation calls are removed
     val description = parameter.descriptionOrAltText()
 
@@ -342,7 +337,6 @@ private fun createResultsDocumentation(result: List<SdsResult>) = buildString {
 }
 
 private fun createResultDocumentation(result: SdsResult) = buildString {
-
     // Remember description before annotation calls are removed
     val description = result.descriptionOrAltText()
 

--- a/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/stdlibDocumentation/DocumentationGenerator.kt
+++ b/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/stdlibDocumentation/DocumentationGenerator.kt
@@ -99,39 +99,8 @@ private fun createPackageDocumentation(
 
     appendLine("# Package `$packageName`")
 
-    // Table of contents
     if (annotations.isNotEmpty() || classes.isNotEmpty() || enums.isNotEmpty() || globalFunctions.isNotEmpty()) {
-        appendLine("\n## Table of Contents\n")
-
-        if (classes.isNotEmpty()) {
-            appendLine("* Classes")
-            classes.forEach {
-                appendLine("  * [`${it.name}`](#class-${it.name})")
-            }
-        }
-
-        if (globalFunctions.isNotEmpty()) {
-            appendLine("* Global functions")
-            globalFunctions.forEach {
-                appendLine("  * [`${it.name}`](#global-function-${it.name})")
-            }
-        }
-
-        if (enums.isNotEmpty()) {
-            appendLine("* Enums")
-            enums.forEach {
-                appendLine("  * [`${it.name}`](#enum-${it.name})")
-            }
-        }
-
-        if (enums.isNotEmpty()) {
-            appendLine("* Annotations")
-            annotations.forEach {
-                appendLine("  * [`${it.name}`](#annotation-${it.name})")
-            }
-        }
-
-        appendLine("\n$horizontalRule\n")
+        appendLine()
     }
 
     // Classes

--- a/docs/DSL/README.md
+++ b/docs/DSL/README.md
@@ -2,8 +2,8 @@
 
 The Safe-DS DSL is split into two main parts:
 
-* The _[workflow language][workflow-language]_ is used to solve specific Machine Learning problems. Unless you want to add functionality to Safe-DS, this sublanguage is all you need to learn. To use the workflow language, create a file with the extension `.sdsflow`.
-* The _[stub language][stub-language]_ is used to integrate external code written in Python into Safe-DS, so it can be used in the [workflow language][workflow-language]. The main purpose of this sublanguage is to define the [Safe-DS Standard Library (stdlib)][stdlib]. To use the stub language, create a file with the extension `.sdsstub`.
+- The _[workflow language][workflow-language]_ is used to solve specific Machine Learning problems. Unless you want to add functionality to Safe-DS, this sublanguage is all you need to learn. To use the workflow language, create a file with the extension `.sdsflow`.
+- The _[stub language][stub-language]_ is used to integrate external code written in Python into Safe-DS, so it can be used in the [workflow language][workflow-language]. The main purpose of this sublanguage is to define the [Safe-DS Standard Library (stdlib)][stdlib]. To use the stub language, create a file with the extension `.sdsstub`.
 
 [workflow-language]: workflow-language/README.md
 [stub-language]: stub-language/README.md

--- a/docs/DSL/README.md
+++ b/docs/DSL/README.md
@@ -7,4 +7,4 @@ The Safe-DS DSL is split into two main parts:
 
 [workflow-language]: workflow-language/README.md
 [stub-language]: stub-language/README.md
-[stdlib]: ../../DSL/com.larsreimann.safeds/src/main/resources/stdlib
+[stdlib]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/com.larsreimann.safeds/src/main/resources/stdlib

--- a/docs/DSL/common/imports.md
+++ b/docs/DSL/common/imports.md
@@ -14,8 +14,8 @@ import safeds.model.regression.DecisionTree
 
 The syntax consists of the following parts:
 
-* The keyword `import`
-* The _qualified name_ of the declaration to import (here `safeds.model.regression.DecisionTree`). The qualified name can be obtained by concatenating the name of the [package][packages] that contains the declaration (i.e. `safeds.model.regression`) with the name of the declaration (i.e. `DecisionTree`). The two parts are separated by a dot.
+- The keyword `import`
+- The _qualified name_ of the declaration to import (here `safeds.model.regression.DecisionTree`). The qualified name can be obtained by concatenating the name of the [package][packages] that contains the declaration (i.e. `safeds.model.regression`) with the name of the declaration (i.e. `DecisionTree`). The two parts are separated by a dot.
 
 Once the declaration is imported, we can refer to it by its _simple name_. This is the last segment of the qualified name, which is the name of the declaration. Here is, for example, a [call][calls] to the constructor of the `DecisionTree` class:
 
@@ -33,10 +33,10 @@ import safeds.model.regression.DecisionTree as StdlibDecisionTree
 
 Let us take apart the syntax:
 
-* The keyword `import`.
-* The _qualified name_ of the declaration to import (here `safeds.model.regression.DecisionTree`). The qualified name can be obtained by concatenating the name of the [package][packages] that contains the declaration (i.e. `safeds.model.regression`) with the name of the declaration (i.e. `DecisionTree`). The two parts are separated by a dot.
-* The keyword `as`.
-* The alias to use (here `StdlibDecisionTree`). This can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number.
+- The keyword `import`.
+- The _qualified name_ of the declaration to import (here `safeds.model.regression.DecisionTree`). The qualified name can be obtained by concatenating the name of the [package][packages] that contains the declaration (i.e. `safeds.model.regression`) with the name of the declaration (i.e. `DecisionTree`). The two parts are separated by a dot.
+- The keyword `as`.
+- The alias to use (here `StdlibDecisionTree`). This can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number.
 
 Afterwards, the declaration can **only** be accessed using the alias. The simple name cannot be used anymore. The next example shows how to create a new instance of the class now by invoking its constructor:
 
@@ -56,10 +56,10 @@ import safeds.model.regression.*
 
 Here is the breakdown of the syntax:
 
-* The keyword `import`.
-* The name of the [package][packages] to import (here `safeds.model.regression`).
-* A dot.
-* A star.
+- The keyword `import`.
+- The name of the [package][packages] to import (here `safeds.model.regression`).
+- A dot.
+- A star.
 
 Afterwards, we can again access declarations by their simple name, such as the [class][classes] `DecisionTree`:
 
@@ -71,9 +71,6 @@ DecisionTree()
 
 Note that declarations in subpackages, i.e. packages that have a different name but the same prefix as the imported one, are **not** imported. Therefore, if we would only `import safeds.model`, we could no longer access the [class][classes] `DecisionTree`.
 
-
-
-[stub-language]: ../stub-language/README.md
 [classes]: ../stub-language/classes.md
 [packages]: packages.md
 [calls]: ../workflow-language/expressions.md#calls

--- a/docs/DSL/common/imports.md
+++ b/docs/DSL/common/imports.md
@@ -13,6 +13,7 @@ import safeds.model.regression.DecisionTree
 ```
 
 The syntax consists of the following parts:
+
 * The keyword `import`
 * The _qualified name_ of the declaration to import (here `safeds.model.regression.DecisionTree`). The qualified name can be obtained by concatenating the name of the [package][packages] that contains the declaration (i.e. `safeds.model.regression`) with the name of the declaration (i.e. `DecisionTree`). The two parts are separated by a dot.
 
@@ -31,6 +32,7 @@ import safeds.model.regression.DecisionTree as StdlibDecisionTree
 ```
 
 Let us take apart the syntax:
+
 * The keyword `import`.
 * The _qualified name_ of the declaration to import (here `safeds.model.regression.DecisionTree`). The qualified name can be obtained by concatenating the name of the [package][packages] that contains the declaration (i.e. `safeds.model.regression`) with the name of the declaration (i.e. `DecisionTree`). The two parts are separated by a dot.
 * The keyword `as`.
@@ -53,6 +55,7 @@ import safeds.model.regression.*
 ```
 
 Here is the breakdown of the syntax:
+
 * The keyword `import`.
 * The name of the [package][packages] to import (here `safeds.model.regression`).
 * A dot.

--- a/docs/DSL/common/packages.md
+++ b/docs/DSL/common/packages.md
@@ -8,8 +8,8 @@ package de.unibonn.speedPrediction
 
 It has these syntactic elements:
 
-* The keyword `package`.
-* The name of the package, which consists of multiple _segments_ separated by dots. Each segment can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `lowerCamelCase` for all segments. We also recommend to use the [reverse domain name notation](https://en.wikipedia.org/wiki/Reverse_domain_name_notation) for the package name.
+- The keyword `package`.
+- The name of the package, which consists of multiple _segments_ separated by dots. Each segment can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `lowerCamelCase` for all segments. We also recommend to use the [reverse domain name notation](https://en.wikipedia.org/wiki/Reverse_domain_name_notation) for the package name.
 
 Multiple files can belong to the same package but each non-empty file must declare its package before any [import][imports] or declarations. Moreover, within the same package the names of declarations must be unique.
 
@@ -99,9 +99,9 @@ Generally, this method is preferable to our initial solution in the Section ["Fi
 
 Choosing the Safe-DS package according to the rules described above is essential for code generation to work properly. However, we might sometimes get warnings related to the Safe-DS naming convention, which wants the segments of the Safe-DS package to be `lowerCamelCase`. We now have several options:
 
-* If the declaration is not part of the Safe-DS standard library, we can ignore the warning.
-* We can update the Python code.
-* We can use the `@PythonModule` annotation.
+- If the declaration is not part of the Safe-DS standard library, we can ignore the warning.
+- We can update the Python code.
+- We can use the `@PythonModule` annotation.
 
 The first two options are self-explanatory. Let us now look at the third one. We use our initial example from the Section ["File Contains Implementation"](#file-contains-implementation) again:
 
@@ -137,8 +137,9 @@ class DecisionTree()
 
 Here is a breakdown of this:
 
-* We [call][annotation-calls] the `@PythonModule` [annotation][annotations] before we declare the Safe-DS package. The [Python module][python-modules] that exports the Python declarations that correspond to the Safe-DS declarations in this stub file is passed as a [string literal][string-literals] (here `safeds.model.regression._decision_tree`). This is used only for code generation and does not affect users of Safe-DS.
-* We specify the Safe-DS package as usual. This must be used when we [import][imports] the declaration in another Safe-DS file:
+- We [call][annotation-calls] the `@PythonModule` [annotation][annotations] before we declare the Safe-DS package. The [Python module][python-modules] that exports the Python declarations that correspond to the Safe-DS declarations in this stub file is passed as a [string literal][string-literals] (here `safeds.model.regression._decision_tree`). This is used only for code generation and does not affect users of Safe-DS.
+- We specify the Safe-DS package as usual. This must be used when we [import][imports] the declaration in another Safe-DS file:
+
     ```txt
     // Safe-DS
 
@@ -151,10 +152,6 @@ It is important to note that the `@PythonModule` annotation only affects the one
 [annotations]: ../stub-language/annotations.md
 [annotation-calls]: ../stub-language/annotations.md#calling-an-annotation
 [imports]: imports.md
-[classes]: ../stub-language/classes.md
-[steps]: ../workflow-language/steps.md
-[workflows]: ../workflow-language/workflows.md
 [string-literals]: ../workflow-language/expressions.md#string-literals
-
 [python-modules]: https://docs.python.org/3/tutorial/modules.html#modules
 [python-packages]: https://docs.python.org/3/tutorial/modules.html#packages

--- a/docs/DSL/common/packages.md
+++ b/docs/DSL/common/packages.md
@@ -7,6 +7,7 @@ package de.unibonn.speedPrediction
 ```
 
 It has these syntactic elements:
+
 * The keyword `package`.
 * The name of the package, which consists of multiple _segments_ separated by dots. Each segment can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `lowerCamelCase` for all segments. We also recommend to use the [reverse domain name notation](https://en.wikipedia.org/wiki/Reverse_domain_name_notation) for the package name.
 
@@ -97,6 +98,7 @@ Generally, this method is preferable to our initial solution in the Section ["Fi
 ### `@PythonModule` Annotation
 
 Choosing the Safe-DS package according to the rules described above is essential for code generation to work properly. However, we might sometimes get warnings related to the Safe-DS naming convention, which wants the segments of the Safe-DS package to be `lowerCamelCase`. We now have several options:
+
 * If the declaration is not part of the Safe-DS standard library, we can ignore the warning.
 * We can update the Python code.
 * We can use the `@PythonModule` annotation.
@@ -134,6 +136,7 @@ class DecisionTree()
 ```
 
 Here is a breakdown of this:
+
 * We [call][annotation-calls] the `@PythonModule` [annotation][annotations] before we declare the Safe-DS package. The [Python module][python-modules] that exports the Python declarations that correspond to the Safe-DS declarations in this stub file is passed as a [string literal][string-literals] (here `safeds.model.regression._decision_tree`). This is used only for code generation and does not affect users of Safe-DS.
 * We specify the Safe-DS package as usual. This must be used when we [import][imports] the declaration in another Safe-DS file:
     ```txt

--- a/docs/DSL/common/parameters.md
+++ b/docs/DSL/common/parameters.md
@@ -2,9 +2,9 @@
 
 _Parameters_ define the expected inputs of some declaration that can be [called][calls]. We refer to such declarations as _callables_. We distinguish between
 
-* [required parameters](#required-parameters), which must always be passed,
-* [optional parameters](#optional-parameters), which use a default value if no value is passed explicitly, and
-* [variadic parameters](#variadic-parameters), which can accept zero or more values.
+- [required parameters](#required-parameters), which must always be passed,
+- [optional parameters](#optional-parameters), which use a default value if no value is passed explicitly, and
+- [variadic parameters](#variadic-parameters), which can accept zero or more values.
 
 ## Required Parameters
 
@@ -16,9 +16,9 @@ requiredParameter: Int
 
 Here are the pieces of syntax:
 
-* The name of the parameter (here `requiredParameter`). This can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `lowerCamelCase` for the names of parameters.
-* A colon.
-* The [type][types] of the parameter (here `Int`).
+- The name of the parameter (here `requiredParameter`). This can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `lowerCamelCase` for the names of parameters.
+- A colon.
+- The [type][types] of the parameter (here `Int`).
 
 ## Optional Parameters
 
@@ -30,11 +30,11 @@ optionalParameter: Int = 1
 
 These are the syntactic elements:
 
-* The name of the parameter (here `optionalParameter`). This can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `lowerCamelCase` for the names of parameters.
-* A colon.
-* The [type][types] of the parameter (here `Int`).
-* An equals sign.
-* The default value of the parameter (here `1`). This must be a constant expression, i.e. something that can be evaluated by the compiler. Particularly [calls][calls] usually do not fulfill this requirement.
+- The name of the parameter (here `optionalParameter`). This can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `lowerCamelCase` for the names of parameters.
+- A colon.
+- The [type][types] of the parameter (here `Int`).
+- An equals sign.
+- The default value of the parameter (here `1`). This must be a constant expression, i.e. something that can be evaluated by the compiler. Particularly [calls][calls] usually do not fulfill this requirement.
 
 ## Variadic Parameters
 
@@ -46,10 +46,10 @@ vararg variadicParameter: Int
 
 Let us break down the syntax:
 
-* The keyword `vararg`
-* The name of the parameter (here `variadicParameter`). This can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `lowerCamelCase` for the names of parameters.
-* A colon.
-* The [type][types] of the parameter (here `Int`).
+- The keyword `vararg`
+- The name of the parameter (here `variadicParameter`). This can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `lowerCamelCase` for the names of parameters.
+- A colon.
+- The [type][types] of the parameter (here `Int`).
 
 ## Complete Example
 
@@ -63,18 +63,17 @@ step doSomething(requiredParameter: Int, optionalParameter: Boolean = false) {
 
 The interesting part is the list of parameters, which uses the following syntactic elements:
 
-* An opening parenthesis.
-* A list of parameters, the syntax is as described above. They are separated by commas. A trailing commas is permitted.
-* A closing parenthesis.
+- An opening parenthesis.
+- A list of parameters, the syntax is as described above. They are separated by commas. A trailing commas is permitted.
+- A closing parenthesis.
 
 ## Restrictions
 
 Several restrictions apply to the order of parameters and to combinations of the various categories of parameters:
 
-* After an [optional parameter](#optional-parameters) all parameters must be optional.
-* A single [variadic parameter](#variadic-parameters) can be added at the end of the parameter list.
-* Implied by this: A callable cannot have both [optional parameters](#optional-parameters) and [variadic parameters](#variadic-parameters).
-
+- After an [optional parameter](#optional-parameters) all parameters must be optional.
+- A single [variadic parameter](#variadic-parameters) can be added at the end of the parameter list.
+- Implied by this: A callable cannot have both [optional parameters](#optional-parameters) and [variadic parameters](#variadic-parameters).
 
 ## Corresponding Python Code
 
@@ -82,10 +81,10 @@ Several restrictions apply to the order of parameters and to combinations of the
 
 Parameters must be ordered the same way in Python as they are in Safe-DS. Moreover, for each parameter the following elements must match:
 
-* Name
-* Type
-* Kind (required vs. optional vs. variadic)
-* Default value for optional parameters
+- Name
+- Type
+- Kind (required vs. optional vs. variadic)
+- Default value for optional parameters
 
 Let's look at these elements in turn.
 
@@ -119,15 +118,15 @@ The Safe-DS type of a parameter should capture the legal values of this paramete
 
 Parameters kinds must match on the Safe-DS and Python sides as well. Concretely, this means:
 
-* All required parameters in Safe-DS must be required in Python.
-* All optional parameters in Safe-DS must be optional in Python.
-* All variadic parameters in Safe-DS must be variadic in Python (`*args`).
+- All required parameters in Safe-DS must be required in Python.
+- All optional parameters in Safe-DS must be optional in Python.
+- All variadic parameters in Safe-DS must be variadic in Python (`*args`).
 
 Moreover, it must be possible to pass
 
-* required parameters by position,
-* optional parameters by name,
-* variadic parameters by position.
+- required parameters by position,
+- optional parameters by name,
+- variadic parameters by position.
 
 These rules allow us to restrict required parameters to [positional-only][python-positional-only] or optional parameters to [keyword-only][python-keyword-only]. We can also keep both unrestricted.
 
@@ -183,7 +182,7 @@ fun variadic(vararg a: Int)
 Most commonly, default values in Python are literals, since default values are only evaluated once in Python rather than every time the function is called. The following table shows how Safe-DS literals and Python literals correspond:
 
 | Safe-DS Literal                       | Python Literal         |
-|---------------------------------------|------------------------|
+| ------------------------------------- | ---------------------- |
 | `1` ([int][int-literals])             | `1`                    |
 | `1.0` ([float][float-literals])       | `1.0`                  |
 | `"hello"` ([string][string-literals]) | `"hello"` or `'hello'` |
@@ -196,12 +195,10 @@ Most commonly, default values in Python are literals, since default values are o
 [steps]: ../workflow-language/steps.md
 [calls]: ../workflow-language/expressions.md#calls
 [stub-language]: ../stub-language/README.md
-[literals]: ../workflow-language/expressions.md#literals
 [int-literals]: ../workflow-language/expressions.md#int-literals
 [float-literals]: ../workflow-language/expressions.md#float-literals
 [string-literals]: ../workflow-language/expressions.md#string-literals
 [boolean-literals]: ../workflow-language/expressions.md#boolean-literals
 [null-literals]: ../workflow-language/expressions.md#null-literal
-
 [python-keyword-only]: https://peps.python.org/pep-3102/
 [python-positional-only]: https://peps.python.org/pep-0570/

--- a/docs/DSL/common/parameters.md
+++ b/docs/DSL/common/parameters.md
@@ -1,6 +1,7 @@
 # Parameters
 
 _Parameters_ define the expected inputs of some declaration that can be [called][calls]. We refer to such declarations as _callables_. We distinguish between
+
 * [required parameters](#required-parameters), which must always be passed,
 * [optional parameters](#optional-parameters), which use a default value if no value is passed explicitly, and
 * [variadic parameters](#variadic-parameters), which can accept zero or more values.
@@ -14,6 +15,7 @@ requiredParameter: Int
 ```
 
 Here are the pieces of syntax:
+
 * The name of the parameter (here `requiredParameter`). This can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `lowerCamelCase` for the names of parameters.
 * A colon.
 * The [type][types] of the parameter (here `Int`).
@@ -27,6 +29,7 @@ optionalParameter: Int = 1
 ```
 
 These are the syntactic elements:
+
 * The name of the parameter (here `optionalParameter`). This can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `lowerCamelCase` for the names of parameters.
 * A colon.
 * The [type][types] of the parameter (here `Int`).
@@ -42,6 +45,7 @@ vararg variadicParameter: Int
 ```
 
 Let us break down the syntax:
+
 * The keyword `vararg`
 * The name of the parameter (here `variadicParameter`). This can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `lowerCamelCase` for the names of parameters.
 * A colon.
@@ -58,6 +62,7 @@ step doSomething(requiredParameter: Int, optionalParameter: Boolean = false) {
 ```
 
 The interesting part is the list of parameters, which uses the following syntactic elements:
+
 * An opening parenthesis.
 * A list of parameters, the syntax is as described above. They are separated by commas. A trailing commas is permitted.
 * A closing parenthesis.
@@ -65,6 +70,7 @@ The interesting part is the list of parameters, which uses the following syntact
 ## Restrictions
 
 Several restrictions apply to the order of parameters and to combinations of the various categories of parameters:
+
 * After an [optional parameter](#optional-parameters) all parameters must be optional.
 * A single [variadic parameter](#variadic-parameters) can be added at the end of the parameter list.
 * Implied by this: A callable cannot have both [optional parameters](#optional-parameters) and [variadic parameters](#variadic-parameters).
@@ -75,6 +81,7 @@ Several restrictions apply to the order of parameters and to combinations of the
 **Note:** This section is only relevant if you are interested in the [stub language][stub-language].
 
 Parameters must be ordered the same way in Python as they are in Safe-DS. Moreover, for each parameter the following elements must match:
+
 * Name
 * Type
 * Kind (required vs. optional vs. variadic)
@@ -111,11 +118,13 @@ The Safe-DS type of a parameter should capture the legal values of this paramete
 ### Matching Kind
 
 Parameters kinds must match on the Safe-DS and Python sides as well. Concretely, this means:
+
 * All required parameters in Safe-DS must be required in Python.
 * All optional parameters in Safe-DS must be optional in Python.
 * All variadic parameters in Safe-DS must be variadic in Python (`*args`).
 
 Moreover, it must be possible to pass
+
 * required parameters by position,
 * optional parameters by name,
 * variadic parameters by position.

--- a/docs/DSL/common/results.md
+++ b/docs/DSL/common/results.md
@@ -7,6 +7,7 @@ result: Int
 ```
 
 Here is a breakdown of the syntax:
+
 * The name of the result (here `result`). This can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `lowerCamelCase` for the names of parameters.
 * A colon.
 * The [type][types] of the parameter (here `Int`).
@@ -22,6 +23,7 @@ step doSomething() -> (result1: Int, result2: Boolean) {
 ```
 
 The interesting part is the list of results, which uses the following syntactic elements:
+
 * An arrow `->`.
 * An opening parenthesis.
 * A list of results, the syntax is as described above. They are separated by commas. A trailing commas is permitted.

--- a/docs/DSL/common/results.md
+++ b/docs/DSL/common/results.md
@@ -8,9 +8,9 @@ result: Int
 
 Here is a breakdown of the syntax:
 
-* The name of the result (here `result`). This can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `lowerCamelCase` for the names of parameters.
-* A colon.
-* The [type][types] of the parameter (here `Int`).
+- The name of the result (here `result`). This can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `lowerCamelCase` for the names of parameters.
+- A colon.
+- The [type][types] of the parameter (here `Int`).
 
 ## Complete Example
 
@@ -24,10 +24,10 @@ step doSomething() -> (result1: Int, result2: Boolean) {
 
 The interesting part is the list of results, which uses the following syntactic elements:
 
-* An arrow `->`.
-* An opening parenthesis.
-* A list of results, the syntax is as described above. They are separated by commas. A trailing commas is permitted.
-* A closing parenthesis.
+- An arrow `->`.
+- An opening parenthesis.
+- A list of results, the syntax is as described above. They are separated by commas. A trailing commas is permitted.
+- A closing parenthesis.
 
 ## Shorthand Version: Single Result
 
@@ -62,7 +62,6 @@ The notable exception are [callable types][callable-types], where the result lis
 Results must be ordered the same way in Python as they are in Safe-DS. Moreover, the Safe-DS type of a result should capture the possible values of this result accurately. Ideally, the Python result should also have a matching [type hint][types-python].
 
 Since Python results do not have a name, the names of Safe-DS results can be arbitrary. Naturally, a name should be chosen that captures the purpose of the result.
-
 
 [stub-language]: ../stub-language/README.md
 [types]: types.md

--- a/docs/DSL/common/types.md
+++ b/docs/DSL/common/types.md
@@ -68,6 +68,7 @@ When we use this [class][classes] as a named type, we need to specify the value 
 In the case of positional type arguments, they are mapped to [type parameters][type-parameters] by position, i.e. the first type argument is assigned to the first [type parameter][type-parameters], the second type argument is assigned to the second [type parameter][type-parameters] and so forth.
 
 If a positional type argument is used, we just write down its value. The value is either
+
 * a [type projection](#type-projection), or
 * a [star projection](#star-projection).
 
@@ -78,6 +79,7 @@ SomeSpecialList<Int>
 ```
 
 Let us break down the syntax:
+
 * The usual named type (here `SomeSpecialList`).
 * Opening angle bracket.
 * A positional type argument (here `Int`).
@@ -90,6 +92,7 @@ SomeSpecialList<T = Int>
 ```
 
 These are the syntactic elements:
+
 * The usual named type (here `SomeSpecialList`).
 * Opening angle bracket.
 * A named type argument (here `T = Int`). This in turn consists of
@@ -164,6 +167,7 @@ SomeSpecialList<*>
 It consists only of the `*`, which we use as the value of the type argument.
 
 The star projection is usually equivalent to the type projections
+
 * `out Any?` (`Any?` is the supertype of everything), or
 * `in Nothing` (`Nothing` is the subtype of everything).
 
@@ -190,6 +194,7 @@ SomeOuterClass.SomeInnerClass
 ```
 
 This has the following syntactic elements:
+
 * Name of the outer [class][classes] (here `SomeOuterClass`).
 * A dot.
 * Name of the inner [class][classes] (here `SomeInnerClass`).
@@ -248,6 +253,7 @@ SomeEnum.SomeEnumVariant
 ```
 
 Let us take apart the syntax:
+
 * The name of the [enum][enums] (here `SomeEnum`).
 * A dot.
 * The name of the [enum variant][variants] (here `SomeEnumVariant`).
@@ -276,6 +282,7 @@ union<String, Int>
 ```
 
 Here is a breakdown of the syntax:
+
 * The keyword `union`.
 * An opening angle bracket.
 * A list of types, which are separated by commas. A trailing comma is allowed.
@@ -300,6 +307,7 @@ Additionally, a callable types specifies the names and types of parameters and r
 ```
 
 Let us break down the syntax:
+
 * A pair of parentheses, which is the list of expected [parameters][parameters].
 * An arrow `->`.
 * A pair of parentheses, which is the list of expected [results][results].
@@ -311,6 +319,7 @@ We can now add some expected [parameters][parameters]:
 ```
 
 These are the syntactic elements:
+
 * [Parameters][parameters] are written in the first pair of parentheses.
 * For each [parameter][parameters], specify:
   * Its name.
@@ -325,6 +334,7 @@ Finally, we can add some expected [results][results]:
 ```
 
 The syntax is reminiscent of the notation for [parameters][parameters]:
+
 * [Results][results] are written in the second pair of parentheses.
 * For each [result][results], specify:
   * Its name.
@@ -391,11 +401,13 @@ Callable[<list of parameter types>, <result type>]
 ```
 
 To get the `<list of parameter types>`, simply
+
 1. convert the types of the parameters to their Python syntax,
 2. separate them all by commas,
 3. surround them by square brackets.
 
 Getting the `<result type`> depends on the number of results. If there is only a single result, simply write down its type. If there are multiple types, do this instead:
+
 1. convert the types of the results to their Python syntax,
 2. separate them all by commas,
 3. add the prefix `Tuple[`,

--- a/docs/DSL/common/types.md
+++ b/docs/DSL/common/types.md
@@ -69,8 +69,8 @@ In the case of positional type arguments, they are mapped to [type parameters][t
 
 If a positional type argument is used, we just write down its value. The value is either
 
-* a [type projection](#type-projection), or
-* a [star projection](#star-projection).
+- a [type projection](#type-projection), or
+- a [star projection](#star-projection).
 
 For example, if we expect a list of integers, we could use the following type:
 
@@ -80,10 +80,10 @@ SomeSpecialList<Int>
 
 Let us break down the syntax:
 
-* The usual named type (here `SomeSpecialList`).
-* Opening angle bracket.
-* A positional type argument (here `Int`).
-* A closing angle bracket.
+- The usual named type (here `SomeSpecialList`).
+- Opening angle bracket.
+- A positional type argument (here `Int`).
+- A closing angle bracket.
 
 When a named type argument is used, we explicitly specify the [type parameter][type-parameters] that we want to assign. This allows us to specify them in any order. It can also improve the clarity of the code since the meaning of the type argument becomes more apparent. Here is the type for our list of integers when a named argument is used:
 
@@ -93,13 +93,13 @@ SomeSpecialList<T = Int>
 
 These are the syntactic elements:
 
-* The usual named type (here `SomeSpecialList`).
-* Opening angle bracket.
-* A named type argument (here `T = Int`). This in turn consists of
-  * The name of the [type parameter][type-parameters] (here `T`)
-  * An equals sign.
-  * The value of the type argument, which is still either a [type projection](#type-projection), or a [star projection](#star-projection).
-* A closing angle bracket.
+- The usual named type (here `SomeSpecialList`).
+- Opening angle bracket.
+- A named type argument (here `T = Int`). This in turn consists of
+  - The name of the [type parameter][type-parameters] (here `T`)
+  - An equals sign.
+  - The value of the type argument, which is still either a [type projection](#type-projection), or a [star projection](#star-projection).
+- A closing angle bracket.
 
 Within a list of type arguments both positional and named type arguments can be used. However, after the first named type arguments all type arguments must be named.
 
@@ -119,10 +119,10 @@ SomeSpecialMap<String, V = Int>
 
 We will again go over the syntax:
 
-* The usual named type (here `SomeSpecialMap`).
-* An opening angle bracket.
-* The list of type arguments. Each element is either a positional or a named type argument (see above). Individual elements are separated by commas. A trailing comma is allowed
-* A closing angle bracket.
+- The usual named type (here `SomeSpecialMap`).
+- An opening angle bracket.
+- The list of type arguments. Each element is either a positional or a named type argument (see above). Individual elements are separated by commas. A trailing comma is allowed
+- A closing angle bracket.
 
 We will now look at the values that we can pass within type arguments.
 
@@ -168,8 +168,8 @@ It consists only of the `*`, which we use as the value of the type argument.
 
 The star projection is usually equivalent to the type projections
 
-* `out Any?` (`Any?` is the supertype of everything), or
-* `in Nothing` (`Nothing` is the subtype of everything).
+- `out Any?` (`Any?` is the supertype of everything), or
+- `in Nothing` (`Nothing` is the subtype of everything).
 
 If the [type parameter][type-parameters] has [bounds][type-parameter-bounds], however, the star projection denotes that any type within the [bounds][type-parameter-bounds] is acceptable.
 
@@ -195,9 +195,9 @@ SomeOuterClass.SomeInnerClass
 
 This has the following syntactic elements:
 
-* Name of the outer [class][classes] (here `SomeOuterClass`).
-* A dot.
-* Name of the inner [class][classes] (here `SomeInnerClass`).
+- Name of the outer [class][classes] (here `SomeOuterClass`).
+- A dot.
+- Name of the inner [class][classes] (here `SomeInnerClass`).
 
 Classes can be nested multiple levels deep. In this case, use a member access for each level. Let us use the following declarations to explain this:
 
@@ -254,9 +254,9 @@ SomeEnum.SomeEnumVariant
 
 Let us take apart the syntax:
 
-* The name of the [enum][enums] (here `SomeEnum`).
-* A dot.
-* The name of the [enum variant][variants] (here `SomeEnumVariant`).
+- The name of the [enum][enums] (here `SomeEnum`).
+- A dot.
+- The name of the [enum variant][variants] (here `SomeEnumVariant`).
 
 Identical to [class member types](#class-member-types), all [type parameters][type-parameters] of the [enum variant][variants] must be assigned by [type arguments](#type-arguments). We use these declarations to explain the concept:
 
@@ -283,22 +283,23 @@ union<String, Int>
 
 Here is a breakdown of the syntax:
 
-* The keyword `union`.
-* An opening angle bracket.
-* A list of types, which are separated by commas. A trailing comma is allowed.
-* A closing angle bracket
+- The keyword `union`.
+- An opening angle bracket.
+- A list of types, which are separated by commas. A trailing comma is allowed.
+- A closing angle bracket
 
 Note that it is preferable to write the common superclass if this is equivalent to the union type. For example, `Number` has the two subclasses `Int` and `Float`. Therefore, it is usually better to write `Number` as the type rather than `union<Int, Float>`. Use the union type only when you are not able to handle the later addition of further subclasses of `Number` other than `Int` or `Float`.
 
 ### Callable Types
 
 A _callable type_ denotes that only values that can be [called][calls] are accepted. This includes:
-* [class constructors][class-constructors]
-* [constructors of enum variants][enum-variant-constructors]
-* [methods][methods]
-* [global functions][global-functions]
-* [steps][steps]
-* [lambdas][lambdas]
+
+- [class constructors][class-constructors]
+- [constructors of enum variants][enum-variant-constructors]
+- [methods][methods]
+- [global functions][global-functions]
+- [steps][steps]
+- [lambdas][lambdas]
 
 Additionally, a callable types specifies the names and types of parameters and results. Here is the most basic callable type that expects neither parameters nor results:
 
@@ -308,9 +309,9 @@ Additionally, a callable types specifies the names and types of parameters and r
 
 Let us break down the syntax:
 
-* A pair of parentheses, which is the list of expected [parameters][parameters].
-* An arrow `->`.
-* A pair of parentheses, which is the list of expected [results][results].
+- A pair of parentheses, which is the list of expected [parameters][parameters].
+- An arrow `->`.
+- A pair of parentheses, which is the list of expected [results][results].
 
 We can now add some expected [parameters][parameters]:
 
@@ -320,12 +321,12 @@ We can now add some expected [parameters][parameters]:
 
 These are the syntactic elements:
 
-* [Parameters][parameters] are written in the first pair of parentheses.
-* For each [parameter][parameters], specify:
-  * Its name.
-  * A colon.
-  * Its type.
-* Separate [parameters][parameters] by commas. A trailing comma is permitted.
+- [Parameters][parameters] are written in the first pair of parentheses.
+- For each [parameter][parameters], specify:
+  - Its name.
+  - A colon.
+  - Its type.
+- Separate [parameters][parameters] by commas. A trailing comma is permitted.
 
 Finally, we can add some expected [results][results]:
 
@@ -335,12 +336,12 @@ Finally, we can add some expected [results][results]:
 
 The syntax is reminiscent of the notation for [parameters][parameters]:
 
-* [Results][results] are written in the second pair of parentheses.
-* For each [result][results], specify:
-  * Its name.
-  * A colon.
-  * Its type.
-* Separate [result][results] by commas. A trailing comma is permitted.
+- [Results][results] are written in the second pair of parentheses.
+- For each [result][results], specify:
+  - Its name.
+  - A colon.
+  - Its type.
+- Separate [result][results] by commas. A trailing comma is permitted.
 
 If exactly one result is expected, the surrounding parentheses may be also removed:
 
@@ -377,7 +378,7 @@ from typing import Callable, Optional, Tuple, TypeVar, Union
 The following table shows how Safe-DS types can be written as Python [type hints][type-hints]:
 
 | Safe-DS Type                           | Python Type Hint                                                   |
-|----------------------------------------|--------------------------------------------------------------------|
+| -------------------------------------- | ------------------------------------------------------------------ |
 | `Boolean`                              | `bool`                                                             |
 | `Float`                                | `float`                                                            |
 | `Int`                                  | `int`                                                              |
@@ -416,7 +417,6 @@ Getting the `<result type`> depends on the number of results. If there is only a
 [variance]: variance.md
 [parameters]: parameters.md
 [results]: results.md
-
 [stub-language]: ../stub-language/README.md
 [classes]: ../stub-language/classes.md
 [subclassing]: ../stub-language/classes.md#subclassing
@@ -429,13 +429,10 @@ Getting the `<result type`> depends on the number of results. If there is only a
 [enum-variant-constructors]: ../stub-language/enumerations.md#constructors
 [methods]: ../stub-language/classes.md#defining-methods
 [global-functions]: ../stub-language/global-functions.md
-
-
 [member-accesses]: ../workflow-language/expressions.md#member-access-of-enum-variants
 [null-literal]: ../workflow-language/expressions.md#null-literal
 [calls]: ../workflow-language/expressions.md#calls
 [steps]: ../workflow-language/steps.md
 [lambdas]: ../workflow-language/expressions.md#lambdas
-
 [mypy]: http://mypy-lang.org/
 [type-hints]: https://docs.python.org/3/library/typing.html

--- a/docs/DSL/common/variance.md
+++ b/docs/DSL/common/variance.md
@@ -13,10 +13,12 @@ class Stack<T>(vararg initialElements: T) {
 ```
 
 The [class][classes] is called `Stack` and has a single [type parameter][type-parameters], which is supposed to the denote the [type][types] of the elements of the stack. With its [constructor], we can specify the initial elements of the stack. Moreover, two [methods][methods] are defined on the stack:
+
 * `push` is supposed to add a new element to the top of the stack.
 * `pop` is supposed to remove and return the topmost element of the stack.
 
 We will now try to answer the following two questions:
+
 1. If `A` is a subclass of `B`, can we assign `Stack<A>` to `Stack<B>`?
 2. If `B` is a subclass of `A`, can we assign `Stack<A>` to `Stack<B>`?
 
@@ -69,7 +71,7 @@ The following table sums up the syntax of [declaration-site variance][declaratio
 | Desired Variance | Declaration Site | Use Site   |
 |------------------|------------------|------------|
 | Invariant        | `class Stack<T>` | `Stack<T>` |
-|Covariant|`class Stack<out T>`|`Stack<out T>`
+|Covariant|`class Stack<out T>`|`Stack<out T>`|
 |Contravariant|`class Stack<in T>`|`Stack<in T>`|
 
 [types]: types.md

--- a/docs/DSL/common/variance.md
+++ b/docs/DSL/common/variance.md
@@ -14,8 +14,8 @@ class Stack<T>(vararg initialElements: T) {
 
 The [class][classes] is called `Stack` and has a single [type parameter][type-parameters], which is supposed to the denote the [type][types] of the elements of the stack. With its [constructor], we can specify the initial elements of the stack. Moreover, two [methods][methods] are defined on the stack:
 
-* `push` is supposed to add a new element to the top of the stack.
-* `pop` is supposed to remove and return the topmost element of the stack.
+- `push` is supposed to add a new element to the top of the stack.
+- `pop` is supposed to remove and return the topmost element of the stack.
 
 We will now try to answer the following two questions:
 
@@ -38,7 +38,7 @@ We say, the [type parameter][type-parameters] `T` of the [class][classes] is inv
 
 We now want a `Stack<A>` to be assignable to a `Stack<B>` if `A` is a subclass of `B`. This behavior is called _covariance_ since the type compatibility relation between `Stack<A>` and `Stack<B>` points in the same direction as the type compatibility relation between `A` and `B`.
 
-As outlined above, we can only allow covariance if we forbid writing access.  This means that a [type parameter][type-parameters] that is covariant can only be used for reading. Concretely, a covariant [type parameter][type-parameters] can only be used as the type of a [result][results] not the type of a [parameter][parameters]. We also say the [type parameter][type-parameters] can only be used in the _out-position_ (i.e. as output), which motivates the keyword `out` to denote covariance (see Section [Specifying Variance](#specifying-variance)).
+As outlined above, we can only allow covariance if we forbid writing access. This means that a [type parameter][type-parameters] that is covariant can only be used for reading. Concretely, a covariant [type parameter][type-parameters] can only be used as the type of a [result][results] not the type of a [parameter][parameters]. We also say the [type parameter][type-parameters] can only be used in the _out-position_ (i.e. as output), which motivates the keyword `out` to denote covariance (see Section [Specifying Variance](#specifying-variance)).
 
 In the `Stack` example, we can make the [class][classes] covariant by adding the keyword `out` to the [type parameter][type-parameters] `T` and removing the writing [method][methods] `push`:
 
@@ -52,7 +52,7 @@ class Stack<out T> {
 
 We now want a `Stack<A>` to be assignable to a `Stack<B>` if `B` is a subclass of `A`. This behavior is called _contravariance_ since the type compatibility relation between `Stack<A>` and `Stack<B>` points in the opposite direction as the type compatibility relation between `A` and `B`.
 
-As outlined above, we can only allow contravariance if we forbid reading access.  This means that a [type parameter][type-parameters] that is contravariant can only be used for writing. Concretely, a contravariant [type parameter][type-parameters] can only be used as the type of a [parameter][parameters] not the type of a [result][results]. We also say the [type parameter][type-parameters] can only be used in the _in-position_ (i.e. as input), which motivates the keyword `in` to denote contravariance (see Section [Specifying Variance](#specifying-variance)).
+As outlined above, we can only allow contravariance if we forbid reading access. This means that a [type parameter][type-parameters] that is contravariant can only be used for writing. Concretely, a contravariant [type parameter][type-parameters] can only be used as the type of a [parameter][parameters] not the type of a [result][results]. We also say the [type parameter][type-parameters] can only be used in the _in-position_ (i.e. as input), which motivates the keyword `in` to denote contravariance (see Section [Specifying Variance](#specifying-variance)).
 
 In the `Stack` example, we can make the [class][classes] contravariant by adding the keyword `in` to the [type parameter][type-parameters] `T` and removing the reading [method][methods] `pop`:
 
@@ -68,11 +68,11 @@ The variance of a [type parameter][type-parameters] can either be declared at it
 
 The following table sums up the syntax of [declaration-site variance][declaration-site-variance], where the [class][classes] declaration is changed, and [use-site variance][use-site-variance], where the [type arguments][type-arguments] passed by the [named type][named-types] Refer to the linked documents for more details.
 
-| Desired Variance | Declaration Site | Use Site   |
-|------------------|------------------|------------|
-| Invariant        | `class Stack<T>` | `Stack<T>` |
-|Covariant|`class Stack<out T>`|`Stack<out T>`|
-|Contravariant|`class Stack<in T>`|`Stack<in T>`|
+| Desired Variance | Declaration Site     | Use Site       |
+| ---------------- | -------------------- | -------------- |
+| Invariant        | `class Stack<T>`     | `Stack<T>`     |
+| Covariant        | `class Stack<out T>` | `Stack<out T>` |
+| Contravariant    | `class Stack<in T>`  | `Stack<in T>`  |
 
 [types]: types.md
 [named-types]: types.md#named-types
@@ -80,9 +80,7 @@ The following table sums up the syntax of [declaration-site variance][declaratio
 [use-site-variance]: types.md#use-site-variance
 [parameters]: parameters.md
 [results]: results.md
-
 [classes]: ../stub-language/classes.md
 [methods]: ../stub-language/classes.md#defining-methods
-[subclassing]: ../stub-language/classes.md#subclassing
 [type-parameters]: ../stub-language/type-parameters.md
 [declaration-site-variance]: ../stub-language/type-parameters.md#declaration-site-variance

--- a/docs/DSL/stub-language/annotations.md
+++ b/docs/DSL/stub-language/annotations.md
@@ -13,6 +13,7 @@ annotation OnlyForExperts
 ```
 
 This declaration of an annotation has the following syntactic elements:
+
 * The keyword `annotation`.
 * The name of the annotation, here `OnlyForExperts`. This can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `UpperCamelCase` for the names of annotations.
 
@@ -62,6 +63,7 @@ class VerySpecificMLModel
 ```
 
 Here is a breakdown of the syntax:
+
 * An `@`.
 * The name of the called annotation (here `OnlyForExperts`).
 

--- a/docs/DSL/stub-language/annotations.md
+++ b/docs/DSL/stub-language/annotations.md
@@ -14,8 +14,8 @@ annotation OnlyForExperts
 
 This declaration of an annotation has the following syntactic elements:
 
-* The keyword `annotation`.
-* The name of the annotation, here `OnlyForExperts`. This can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `UpperCamelCase` for the names of annotations.
+- The keyword `annotation`.
+- The name of the annotation, here `OnlyForExperts`. This can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `UpperCamelCase` for the names of annotations.
 
 ### Parameters
 
@@ -40,18 +40,18 @@ As we can see from the `OnlyForExperts` example, we can omit the entire paramete
 
 To attach metainformation to a declaration, the annotation must be called on that declaration. We name the annotated declaration the _target_ of the annotation. Possible targets are
 
-* [Annotations](#declaring-an-annotation) (yes, annotations can be the target of annotation calls)
-* [Attributes][attributes]
-* [Classes][classes]
-* Compilation units (entire files)
-* [Enums][enums]
-* [Enum variants][enum-variants]
-* [Global functions][global-functions] / [methods][methods]
-* [Parameters][parameters]
-* [Results][results]
-* [Steps][steps]
-* [Type parameters][type-parameters]
-* [Workflows][workflows]
+- [Annotations](#declaring-an-annotation) (yes, annotations can be the target of annotation calls)
+- [Attributes][attributes]
+- [Classes][classes]
+- Compilation units (entire files)
+- [Enums][enums]
+- [Enum variants][enum-variants]
+- [Global functions][global-functions] / [methods][methods]
+- [Parameters][parameters]
+- [Results][results]
+- [Steps][steps]
+- [Type parameters][type-parameters]
+- [Workflows][workflows]
 
 The valid targets of an annotation can be restricted with the [`Target`][safeds-lang-target] annotation. By default all targets are allowed. Likewise, an annotation can only be called once on the same declaration by default, unless the annotation is marked as[Repeatable][safeds-lang-repeatable].
 
@@ -64,8 +64,8 @@ class VerySpecificMLModel
 
 Here is a breakdown of the syntax:
 
-* An `@`.
-* The name of the called annotation (here `OnlyForExperts`).
+- An `@`.
+- The name of the called annotation (here `OnlyForExperts`).
 
 The code `class VerySpecificMLModel` is **not** part of the annotation call but simply the [class declaration][classes] that is targeted by the annotation call. Since the annotation `OnlyForExperts` does not specify parameters, we also need not pass arguments and can omit the entire argument list.
 
@@ -89,8 +89,8 @@ The same [restrictions to arguments][argument-restrictions] as for [calls][calls
 
 The package `safeds.lang` contains several annotations that are processed by Safe-DS. Refer to the [API documentation][safeds-lang] for more details. Particularly important are the annotations
 
-* [`Target`][safeds-lang-target], which can restrict the possible targets of an annotation, and
-* [`Repeatable`][safeds-lang-repeatable], which allows an annotation to be called multiple times on the same declaration.
+- [`Target`][safeds-lang-target], which can restrict the possible targets of an annotation, and
+- [`Repeatable`][safeds-lang-repeatable], which allows an annotation to be called multiple times on the same declaration.
 
 [parameters]: ../common/parameters.md
 [types]: ../common/types.md

--- a/docs/DSL/stub-language/enumerations.md
+++ b/docs/DSL/stub-language/enumerations.md
@@ -6,9 +6,9 @@ An enumeration is a datatype that can take a fixed, finite set of values. The [R
 
 The syntax to declare an enumeration is as follows:
 
-* The keyword `enum`.
-* The name of the enumeration.
-* A list of the _instances_, i. e. the valid values of the enumeration enclosed in curly braces and separated by commas.
+- The keyword `enum`.
+- The name of the enumeration.
+- A list of the _instances_, i. e. the valid values of the enumeration enclosed in curly braces and separated by commas.
 
 Coming back to the ridge solver example from the introduction, we would implement this in Safe-DS as follows, so that only the seven specified values are valid instances of the datatype.
 

--- a/docs/DSL/stub-language/enumerations.md
+++ b/docs/DSL/stub-language/enumerations.md
@@ -5,6 +5,7 @@ An enumeration is a datatype that can take a fixed, finite set of values. The [R
 ## Declaring an Enumeration
 
 The syntax to declare an enumeration is as follows:
+
 * The keyword `enum`.
 * The name of the enumeration.
 * A list of the _instances_, i. e. the valid values of the enumeration enclosed in curly braces and separated by commas.

--- a/docs/DSL/stub-language/global-functions.md
+++ b/docs/DSL/stub-language/global-functions.md
@@ -5,6 +5,7 @@ In order to use a method of a [class][classes] we first must get hold of an inst
 ## Defining a Global Function
 
 The syntax to define a global function is as follows:
+
 * The keyword `fun`
 * The name of the function ("loadDataset" in the following example)
 * The list of _parameters_ (inputs) enclosed in parentheses and separated by commas (`(name: String)` in the following snippet). For each parameter we list the name of the parameter followed by a colon and its type.

--- a/docs/DSL/stub-language/global-functions.md
+++ b/docs/DSL/stub-language/global-functions.md
@@ -6,11 +6,11 @@ In order to use a method of a [class][classes] we first must get hold of an inst
 
 The syntax to define a global function is as follows:
 
-* The keyword `fun`
-* The name of the function ("loadDataset" in the following example)
-* The list of _parameters_ (inputs) enclosed in parentheses and separated by commas (`(name: String)` in the following snippet). For each parameter we list the name of the parameter followed by a colon and its type.
-* Optionally we can list the _results_ (outputs) after the symbol `->`. If this section is missing it means the global function does not produce results. The list of results is again enclosed in parentheses and we use commas to separate the entries. If there is exactly one result we can omit the parentheses (see `-> dataset: Dataset` in the following example). For each result we specify its name followed by a colon and its type.
-* Note that global functions do **not** have a body since they are part of the [stub language][stub-language], which does not deal with implementation.
+- The keyword `fun`
+- The name of the function ("loadDataset" in the following example)
+- The list of _parameters_ (inputs) enclosed in parentheses and separated by commas (`(name: String)` in the following snippet). For each parameter we list the name of the parameter followed by a colon and its type.
+- Optionally we can list the _results_ (outputs) after the symbol `->`. If this section is missing it means the global function does not produce results. The list of results is again enclosed in parentheses and we use commas to separate the entries. If there is exactly one result we can omit the parentheses (see `-> dataset: Dataset` in the following example). For each result we specify its name followed by a colon and its type.
+- Note that global functions do **not** have a body since they are part of the [stub language][stub-language], which does not deal with implementation.
 
 ```txt
 fun loadDataset(name: String) -> dataset: Dataset

--- a/docs/DSL/workflow-language/expressions.md
+++ b/docs/DSL/workflow-language/expressions.md
@@ -14,15 +14,15 @@ Int literals denote integers. They use the expected syntax. For example, the int
 
 Float literals denote floating point numbers. There are two ways to specify them:
 
-* **Decimal form**: One half can be written as `0.5`. Note that neither the integer part nor the decimal part can be omitted, so `.5` and `0.` are syntax errors.
-* **Scientific notation**: Writing very large or very small numbers in decimal notation can be cumbersome. In those cases, [scientific notation](https://en.wikipedia.org/wiki/Scientific_notation) is helpful. For example, one thousandth can be written in Safe-DS as `1.0e-3` or `1.0E-3`. You can read this as `1.0 × 10⁻³`. When scientific notation is used, it is allowed to omit the decimal part, so this can be shortened to `1e-3` or `1E-3`.
+- **Decimal form**: One half can be written as `0.5`. Note that neither the integer part nor the decimal part can be omitted, so `.5` and `0.` are syntax errors.
+- **Scientific notation**: Writing very large or very small numbers in decimal notation can be cumbersome. In those cases, [scientific notation](https://en.wikipedia.org/wiki/Scientific_notation) is helpful. For example, one thousandth can be written in Safe-DS as `1.0e-3` or `1.0E-3`. You can read this as `1.0 × 10⁻³`. When scientific notation is used, it is allowed to omit the decimal part, so this can be shortened to `1e-3` or `1E-3`.
 
 ### String Literals
 
 String literals describe text. Their syntax is simply text enclosed by double quotes: `"Hello, world!"`. Various special characters can be denoted with _escape sequences_:
 
 | Escape sequence | Meaning                                                              |
-|-----------------|----------------------------------------------------------------------|
+| --------------- | -------------------------------------------------------------------- |
 | `\b`            | Backspace                                                            |
 | `\t`            | Tab                                                                  |
 | `\n`            | New line                                                             |
@@ -55,50 +55,52 @@ To denote that a value is unknown or absent, use the literal `null`.
 ## Operations
 
 Operations are special functions that can be applied to one or two expressions. Safe-DS has a fixed set of operations that cannot be extended. We distinguish between
-* prefix operations (general form `<operator> <operand>`), and
-* infix operations (general form `<left operand> <operator> <right operand>`).
+
+- prefix operations (general form `<operator> <operand>`), and
+- infix operations (general form `<left operand> <operator> <right operand>`).
 
 ### Operations on Numbers
 
 Numbers can be negated using the unary `-` operator:
 
-* The integer negative three is `-3`.
-* The float negative three is `-3.0`.
+- The integer negative three is `-3`.
+- The float negative three is `-3.0`.
 
 The usual arithmetic operations are also supported for integers, floats and combinations of the two. Note that when either operand is a float, the whole expression is evaluated to a float.
 
-* Addition: `0 + 5` (result is an integer)
-* Subtraction: `6 - 2.9` (result is a float)
-* Multiplication: `1.1 * 3` (result is a float)
-* Division: `1.0 / 4.2` (result is a float)
+- Addition: `0 + 5` (result is an integer)
+- Subtraction: `6 - 2.9` (result is a float)
+- Multiplication: `1.1 * 3` (result is a float)
+- Division: `1.0 / 4.2` (result is a float)
 
 Finally, two numbers can be compared, which results in a boolean. The integer `3` for example is less than the integer `5`. Safe-DS offers operators to do such checks for order:
 
-* Less than: `5 < 6`
-* Less than or equal: `1 <= 3`
-* Greater than or equal: `7 >= 7`
-* Greater than: `9 > 2`
+- Less than: `5 < 6`
+- Less than or equal: `1 <= 3`
+- Greater than or equal: `7 >= 7`
+- Greater than: `9 > 2`
 
 ### Logical Operations
 
 To work with logic, Safe-DS has the two boolean literals `false` and `true` as well as operations to work with them:
-* (Logical) **negation** (example `not a`): Output is `true` if and only if the operand is false:
+
+- (Logical) **negation** (example `not a`): Output is `true` if and only if the operand is false:
 
 | `not a` | false | true  |
-|---------|-------|-------|
+| ------- | ----- | ----- |
 | &nbsp;  | true  | false |
 
-* **Conjunction** (example `a and b`): Output is `true` if and only if both operands are `true`. Note that the second operand is always evaluated, even if the first operand is `false` and, thus, already determines the result of the expression. The operator is not short-circuited:
+- **Conjunction** (example `a and b`): Output is `true` if and only if both operands are `true`. Note that the second operand is always evaluated, even if the first operand is `false` and, thus, already determines the result of the expression. The operator is not short-circuited:
 
 | `a and b` | false | true  |
-|-----------|-------|-------|
+| --------- | ----- | ----- |
 | **false** | false | false |
 | **true**  | false | true  |
 
-* **Disjunction** (example `a or b`): Output is `true` if and only if at least one operand is `true`. Note that the second operand is always evaluated, even if the first operand is `true` and, thus, already determines the result of the expression. The operator is not short-circuited:
+- **Disjunction** (example `a or b`): Output is `true` if and only if at least one operand is `true`. Note that the second operand is always evaluated, even if the first operand is `true` and, thus, already determines the result of the expression. The operator is not short-circuited:
 
 | `a or b`  | false | true |
-|-----------|-------|------|
+| --------- | ----- | ---- |
 | **false** | false | true |
 | **true**  | true  | true |
 
@@ -106,13 +108,13 @@ To work with logic, Safe-DS has the two boolean literals `false` and `true` as w
 
 There are two different types of equality in Safe-DS, _identity_ and _structural equality_. Identity checks if two objects are one and the same, whereas structural equality checks if two objects have the same structure and content. Using a real world example, two phones of the same type would be structurally equal but not identical. Both types of equality checks return a boolean literal `true` if the check was positive and `false` if the check was negative. The syntax for these operations is as follows:
 
-* Identity: `1 === 2`
-* Structural equality: `1 == 2`
+- Identity: `1 === 2`
+- Structural equality: `1 == 2`
 
 Safe-DS also has shorthand versions for negated equality checks which should be used instead of an explicit logical negation with the `not` operator:
 
-* Negated identity: `1 !== 2`
-* Negated structural equality: `1 != 2`
+- Negated identity: `1 !== 2`
+- Negated structural equality: `1 != 2`
 
 ### Elvis Operator
 
@@ -167,8 +169,8 @@ This calls the [step][steps] `createDecisionTree`, using the default `maxDepth` 
 
 The syntax consists of these elements:
 
-* The _callee_ of the call, which is the expression to call (here a [reference](#references) to the [step][steps] `createDecisionTree`)
-* The list of arguments, which is delimited by parentheses. In this case the list is empty, so no arguments are passed.
+- The _callee_ of the call, which is the expression to call (here a [reference](#references) to the [step][steps] `createDecisionTree`)
+- The list of arguments, which is delimited by parentheses. In this case the list is empty, so no arguments are passed.
 
 If we want to override the default value of an optional [parameter][parameters] or if the callee has required [parameters][parameters], we need to pass arguments. We can either use _positional arguments_ or _named arguments_.
 
@@ -188,9 +190,9 @@ createDecisionTree(maxDepth = 5)
 
 These are the syntactic elements:
 
-* The name of the parameter for which we want to specify a value.
-* An equals sign.
-* The value to assign to the parameter.
+- The name of the parameter for which we want to specify a value.
+- An equals sign.
+- The value to assign to the parameter.
 
 ### Passing Multiple Arguments
 
@@ -214,33 +216,34 @@ We have already seen the syntax for a single argument. If we want to pass multip
 
 There are some restriction regarding the choice of positional vs. named arguments and passing arguments in general:
 
-* For all [parameters][parameters] of the callee there must be at most one argument.
-* For all [required parameters][required-parameters] there must be exactly one argument.
-* After a named argument all arguments must be named.
-* [Variadic parameters][variadic-parameters] can only be assigned by position.
+- For all [parameters][parameters] of the callee there must be at most one argument.
+- For all [required parameters][required-parameters] there must be exactly one argument.
+- After a named argument all arguments must be named.
+- [Variadic parameters][variadic-parameters] can only be assigned by position.
+
 ### Legal Callees
 
 Depending on the callee, a call can do different things. The following table lists all legal callees and what happens if they are called:
 
 | Callee                                           | Meaning                                                                                                                        |
-|--------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ | --- |
 | [Class][classes]                                 | Create a new instance of the class. The class must have a constructor to be callable. The call evaluates to this new instance. |
 | [Enum Variant][enum-variants]                    | Creates a new instance of the enum variant. Enum variants are always callable. The call evaluates to this new instance.        |
 | [Global Function][global-functions]              | Invokes the function and runs the associated Python code. The call evaluates to the result record of the function.             |
 | [Method][methods]                                | Invokes the method and runs the associated Python code. The call evaluates to the result record of the method.                 |
-| [Step][steps]                                    | Invokes the step and runs the Safe-DS code in its body. The call evaluates to the result record of the step.                   ||
-| [Block Lambda](#block-lambdas)                   | Invokes the lambda and runs the Safe-DS code in its body. The call evaluates to the result record of the lambda.               ||
-| [Expression Lambda](#expression-lambdas)         | Invokes the lambda and runs the Safe-DS code in its body. The call evaluates to the result record of the lambda.               ||
+| [Step][steps]                                    | Invokes the step and runs the Safe-DS code in its body. The call evaluates to the result record of the step.                   |     |
+| [Block Lambda](#block-lambdas)                   | Invokes the lambda and runs the Safe-DS code in its body. The call evaluates to the result record of the lambda.               |     |
+| [Expression Lambda](#expression-lambdas)         | Invokes the lambda and runs the Safe-DS code in its body. The call evaluates to the result record of the lambda.               |     |
 | Declaration with [Callable Type][callable-types] | Call whatever the value of the declaration is.                                                                                 |
 
 #### Result Record
 
 The term _result record_ warrants further explanation: A result record maps [results][results] of a
 
-* [global function][global-functions],
-* [method][methods],
-* [step][steps], or
-* [lambda](#lambdas)
+- [global function][global-functions],
+- [method][methods],
+- [step][steps], or
+- [lambda](#lambdas)
 
 to their computed values.
 
@@ -250,11 +253,12 @@ If the result record only has a single entry, its value can be accessed directly
 
 A member access is used to refer to members of a complex data structure such as
 
-* a [class][classes],
-* an [enum][enums], or
-* the [result record](#result-record) of a [call](#calls).
+- a [class][classes],
+- an [enum][enums], or
+- the [result record](#result-record) of a [call](#calls).
 
 The general syntax of a member access is this:
+
 ```txt
 <receiver>.<member>
 ```
@@ -287,9 +291,9 @@ DecisionTree.verboseTraining
 
 These are the syntactic elements of this member access:
 
-* The receiver, which is the name of the class (here `DecisionTree`)
-* A dot.
-* The name of the static member of the class (here `verboseTraining`)
+- The receiver, which is the name of the class (here `DecisionTree`)
+- A dot.
+- The name of the static member of the class (here `verboseTraining`)
 
 Note that we cannot access a static member from an instance of the class. We must use the class itself.
 
@@ -303,9 +307,9 @@ DecisionTree().maxDepth
 
 We now take apart the syntax again:
 
-* The receiver, here a [call](#calls) of the constructor of the class `DecisionTree`. This creates an instance of this class.
-* A dot.
-* The name of the instance member (here `maxDepth`).
+- The receiver, here a [call](#calls) of the constructor of the class `DecisionTree`. This creates an instance of this class.
+- A dot.
+- The name of the instance member (here `maxDepth`).
 
 Note that instance members cannot be accessed from the class itself, but only from its instances.
 
@@ -340,9 +344,9 @@ SvmKernel.Linear
 
 These are the elements of the syntax:
 
-* The receiver, which is the name of the [enum][enums] (here `SvmKernel`).
-* A dot.
-* The name of the [variant][enum-variants] (here `Linear`).
+- The receiver, which is the name of the [enum][enums] (here `SvmKernel`).
+- A dot.
+- The name of the [variant][enum-variants] (here `Linear`).
 
 This syntax is identical to the [member access of static class members](#member-access-of-static-class-member).
 
@@ -364,9 +368,9 @@ divideWithRemainder(12, 5).remainder
 
 Here are the syntactic elements:
 
-* The receiver, which is a [call](#calls).
-* A dot.
-* The name of the result (here `remainder`).
+- The receiver, which is a [call](#calls).
+- A dot.
+- The name of the result (here `remainder`).
 
 While it is also possible to access the result by name if the [result record](#result-record) contains only a single entry, there is no need to do so, since this result can be used directly. If you still use a member access and the singular result of the call has the same name as an instance member of the corresponding class, the instance member wins.
 
@@ -408,10 +412,10 @@ step printFirst(vararg values: Int) {
 
 These are the elements of the syntax:
 
-* The name of the variadic parameter (here `values`).
-* An opening square bracket.
-* The index, which is an expression that evaluates to an integer. The first element has index 0.
-* A closing square bracket.
+- The name of the variadic parameter (here `values`).
+- An opening square bracket.
+- The index, which is an expression that evaluates to an integer. The first element has index 0.
+- A closing square bracket.
 
 Note that accessing a value at an index outside the bounds of the value list currently only raises an error at runtime.
 
@@ -490,8 +494,9 @@ intListOf(1, 4, 11).filter(
 While this appears longer than the solution with [steps][steps], note that it replaces both the declaration of the [step][steps] as well as the [reference](#references) to it.
 
 Here are the syntactic elements:
-* A list of [parameters][parameters], which is enclosed in parentheses. Individual parameters are separated by commas.
-* The _body_, which is a list of [statements][statements] enclosed in curly braces. Note that each [statement][statements] is terminated by a semicolon.
+
+- A list of [parameters][parameters], which is enclosed in parentheses. Individual parameters are separated by commas.
+- The _body_, which is a list of [statements][statements] enclosed in curly braces. Note that each [statement][statements] is terminated by a semicolon.
 
 The results of a block lambda are [declared in its body using assignments][assignments-to-block-lambda-results].
 
@@ -507,9 +512,9 @@ intListOf(1, 4, 11).filter(
 
 These are the syntactic elements:
 
-* A list of [parameters][parameters], which is enclosed in parentheses. Individual parameters are separated by commas.
-* An arrow `->`.
-* The expression that should be returned.
+- A list of [parameters][parameters], which is enclosed in parentheses. Individual parameters are separated by commas.
+- An arrow `->`.
+- The expression that should be returned.
 
 ### Closures
 
@@ -530,29 +535,30 @@ The interesting part here is that we [refer to](#references) to the [parameter][
 ### Restrictions
 
 At the moment, lambdas can only be used if the context determines the type of its parameters. Concretely, this means we can use lambdas in these two places:
-* As an argument that is assigned to a [parameter][parameters] with a [type][types] in a [call](#calls).
-* As the value that is [assigned to a result of a step][assignments-to-step-results].
-In other cases, declare a step instead and use a [reference](#references) to this step where you would write the lambda.
+
+- As an argument that is assigned to a [parameter][parameters] with a [type][types] in a [call](#calls).
+- As the value that is [assigned to a result of a step][assignments-to-step-results].
+    In other cases, declare a step instead and use a [reference](#references) to this step where you would write the lambda.
 
 ## Precedence
 
 We all know that `2 + 3 * 7` is `23` and not `35`. The reason is that the `*` operator has a higher precedence than the `+` operator and is, therefore, evaluated first. These precedence rules are necessary for all types of expressions listed above and shown in the following list. The higher up an expression is in the list, the higher its precedence and the earlier it is evaluated. Expressions listed beside each other have the same precedence and are evaluated from left to right:
 
-* **HIGHER PRECEDENCE**
-* `()` (parentheses around an expression)
-* `1` ([integer literals](#int-literals)), `1.0` ([float literals](#float-literals)), `"a"` ([string literals](#string-literals)), `true`/`false` ([boolean literals](#boolean-literals)), `null` ([null literal](#null-literal)), `someName` ([references](#references)), `"age: {{ age }}"` ([template strings](#template-strings))
-* `()` ([calls](#calls)), `.` ([member accesses](#member-accesses)), `?.` ([null-safe member accesses](#null-safe-member-access)), `[]` ([indexed accesses](#indexed-accesses))
-* `-` (unary, [arithmetic negations](#operations-on-numbers))
-* `?:` ([Elvis operators](#elvis-operator))
-* `*`, `/` ([multiplicative operators](#operations-on-numbers))
-* `+`, `-` (binary, [additive operators](#operations-on-numbers))
-* `<`, `<=`, `>=`, `>` ([comparison operators](#operations-on-numbers))
-* `===`, `==`, `!==`, `!=` ([equality operators](#equality-checks))
-* `not` ([logical negations](#logical-operations))
-* `and` ([conjunctions](#logical-operations))
-* `or` ([disjunctions](#logical-operations))
-* `() -> 1` ([expression lambdas](#expression-lambdas)), `() {}` ([block lambdas](#block-lambdas))
-* **LOWER PRECEDENCE**
+- **HIGHER PRECEDENCE**
+- `()` (parentheses around an expression)
+- `1` ([integer literals](#int-literals)), `1.0` ([float literals](#float-literals)), `"a"` ([string literals](#string-literals)), `true`/`false` ([boolean literals](#boolean-literals)), `null` ([null literal](#null-literal)), `someName` ([references](#references)), `"age: {{ age }}"` ([template strings](#template-strings))
+- `()` ([calls](#calls)), `.` ([member accesses](#member-accesses)), `?.` ([null-safe member accesses](#null-safe-member-access)), `[]` ([indexed accesses](#indexed-accesses))
+- `-` (unary, [arithmetic negations](#operations-on-numbers))
+- `?:` ([Elvis operators](#elvis-operator))
+- `*`, `/` ([multiplicative operators](#operations-on-numbers))
+- `+`, `-` (binary, [additive operators](#operations-on-numbers))
+- `<`, `<=`, `>=`, `>` ([comparison operators](#operations-on-numbers))
+- `===`, `==`, `!==`, `!=` ([equality operators](#equality-checks))
+- `not` ([logical negations](#logical-operations))
+- `and` ([conjunctions](#logical-operations))
+- `or` ([disjunctions](#logical-operations))
+- `() -> 1` ([expression lambdas](#expression-lambdas)), `() {}` ([block lambdas](#block-lambdas))
+- **LOWER PRECEDENCE**
 
 If the default precedence of operators is not sufficient, parentheses can be used to force a part of an expression to be evaluated first.
 
@@ -560,19 +566,16 @@ If the default precedence of operators is not sufficient, parentheses can be use
 [packages]: ../common/packages.md
 [parameters]: ../common/parameters.md
 [required-parameters]: ../common/parameters.md#required-parameters
-[optional-parameters]: ../common/parameters.md#optional-parameters
 [variadic-parameters]: ../common/parameters.md#variadic-parameters
 [results]: ../common/results.md
 [types]: ../common/types.md
 [callable-types]: ../common/types.md#callable-types
-
 [classes]: ../stub-language/classes.md
 [attributes]: ../stub-language/classes.md#defining-attributes
 [methods]: ../stub-language/classes.md#defining-methods
 [enums]: ../stub-language/enumerations.md
 [enum-variants]: ../stub-language/enumerations.md#enum-variants
 [global-functions]: ../stub-language/global-functions.md
-
 [workflow-language]: README.md
 [statements]: statements.md
 [assignment-multiple-assignees]: statements.md#multiple-assignees

--- a/docs/DSL/workflow-language/expressions.md
+++ b/docs/DSL/workflow-language/expressions.md
@@ -13,6 +13,7 @@ Int literals denote integers. They use the expected syntax. For example, the int
 ### Float Literals
 
 Float literals denote floating point numbers. There are two ways to specify them:
+
 * **Decimal form**: One half can be written as `0.5`. Note that neither the integer part nor the decimal part can be omitted, so `.5` and `0.` are syntax errors.
 * **Scientific notation**: Writing very large or very small numbers in decimal notation can be cumbersome. In those cases, [scientific notation](https://en.wikipedia.org/wiki/Scientific_notation) is helpful. For example, one thousandth can be written in Safe-DS as `1.0e-3` or `1.0E-3`. You can read this as `1.0 × 10⁻³`. When scientific notation is used, it is allowed to omit the decimal part, so this can be shortened to `1e-3` or `1E-3`.
 
@@ -60,10 +61,12 @@ Operations are special functions that can be applied to one or two expressions. 
 ### Operations on Numbers
 
 Numbers can be negated using the unary `-` operator:
+
 * The integer negative three is `-3`.
 * The float negative three is `-3.0`.
 
 The usual arithmetic operations are also supported for integers, floats and combinations of the two. Note that when either operand is a float, the whole expression is evaluated to a float.
+
 * Addition: `0 + 5` (result is an integer)
 * Subtraction: `6 - 2.9` (result is a float)
 * Multiplication: `1.1 * 3` (result is a float)
@@ -81,23 +84,23 @@ Finally, two numbers can be compared, which results in a boolean. The integer `3
 To work with logic, Safe-DS has the two boolean literals `false` and `true` as well as operations to work with them:
 * (Logical) **negation** (example `not a`): Output is `true` if and only if the operand is false:
 
-`not a` | false | true
---------|-------|------
-&nbsp;  | true  | false
+| `not a` | false | true  |
+|---------|-------|-------|
+| &nbsp;  | true  | false |
 
 * **Conjunction** (example `a and b`): Output is `true` if and only if both operands are `true`. Note that the second operand is always evaluated, even if the first operand is `false` and, thus, already determines the result of the expression. The operator is not short-circuited:
 
-`a and b` | false | true
-----------|-------|------
-**false** | false | false
-**true**  | false | true
+| `a and b` | false | true  |
+|-----------|-------|-------|
+| **false** | false | false |
+| **true**  | false | true  |
 
 * **Disjunction** (example `a or b`): Output is `true` if and only if at least one operand is `true`. Note that the second operand is always evaluated, even if the first operand is `true` and, thus, already determines the result of the expression. The operator is not short-circuited:
 
-`a or b`  | false | true
-----------|-------|-----
-**false** | false | true
-**true**  | true  | true
+| `a or b`  | false | true |
+|-----------|-------|------|
+| **false** | false | true |
+| **true**  | true  | true |
 
 ### Equality Checks
 
@@ -163,6 +166,7 @@ createDecisionTree()
 This calls the [step][steps] `createDecisionTree`, using the default `maxDepth` of `10`.
 
 The syntax consists of these elements:
+
 * The _callee_ of the call, which is the expression to call (here a [reference](#references) to the [step][steps] `createDecisionTree`)
 * The list of arguments, which is delimited by parentheses. In this case the list is empty, so no arguments are passed.
 
@@ -183,6 +187,7 @@ createDecisionTree(maxDepth = 5)
 ```
 
 These are the syntactic elements:
+
 * The name of the parameter for which we want to specify a value.
 * An equals sign.
 * The value to assign to the parameter.
@@ -208,6 +213,7 @@ We have already seen the syntax for a single argument. If we want to pass multip
 ### Restrictions For Arguments
 
 There are some restriction regarding the choice of positional vs. named arguments and passing arguments in general:
+
 * For all [parameters][parameters] of the callee there must be at most one argument.
 * For all [required parameters][required-parameters] there must be exactly one argument.
 * After a named argument all arguments must be named.
@@ -216,20 +222,21 @@ There are some restriction regarding the choice of positional vs. named argument
 
 Depending on the callee, a call can do different things. The following table lists all legal callees and what happens if they are called:
 
-| Callee                              | Meaning                                                                                                                        |
-|-------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| [Class][classes]                    | Create a new instance of the class. The class must have a constructor to be callable. The call evaluates to this new instance. |
-| [Enum Variant][enum-variants]       | Creates a new instance of the enum variant. Enum variants are always callable. The call evaluates to this new instance.        |
-| [Global Function][global-functions] | Invokes the function and runs the associated Python code. The call evaluates to the result record of the function.             |
-| [Method][methods]                   | Invokes the method and runs the associated Python code. The call evaluates to the result record of the method.                 |
-|[Step][steps]|Invokes the step and runs the Safe-DS code in its body. The call evaluates to the result record of the step.||
-|[Block Lambda](#block-lambdas)|Invokes the lambda and runs the Safe-DS code in its body. The call evaluates to the result record of the lambda.||
-|[Expression Lambda](#expression-lambdas)|Invokes the lambda and runs the Safe-DS code in its body. The call evaluates to the result record of the lambda.||
-|Declaration with [Callable Type][callable-types]|Call whatever the value of the declaration is.
+| Callee                                           | Meaning                                                                                                                        |
+|--------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| [Class][classes]                                 | Create a new instance of the class. The class must have a constructor to be callable. The call evaluates to this new instance. |
+| [Enum Variant][enum-variants]                    | Creates a new instance of the enum variant. Enum variants are always callable. The call evaluates to this new instance.        |
+| [Global Function][global-functions]              | Invokes the function and runs the associated Python code. The call evaluates to the result record of the function.             |
+| [Method][methods]                                | Invokes the method and runs the associated Python code. The call evaluates to the result record of the method.                 |
+| [Step][steps]                                    | Invokes the step and runs the Safe-DS code in its body. The call evaluates to the result record of the step.                   ||
+| [Block Lambda](#block-lambdas)                   | Invokes the lambda and runs the Safe-DS code in its body. The call evaluates to the result record of the lambda.               ||
+| [Expression Lambda](#expression-lambdas)         | Invokes the lambda and runs the Safe-DS code in its body. The call evaluates to the result record of the lambda.               ||
+| Declaration with [Callable Type][callable-types] | Call whatever the value of the declaration is.                                                                                 |
 
 #### Result Record
 
 The term _result record_ warrants further explanation: A result record maps [results][results] of a
+
 * [global function][global-functions],
 * [method][methods],
 * [step][steps], or
@@ -242,6 +249,7 @@ If the result record only has a single entry, its value can be accessed directly
 ## Member Accesses
 
 A member access is used to refer to members of a complex data structure such as
+
 * a [class][classes],
 * an [enum][enums], or
 * the [result record](#result-record) of a [call](#calls).
@@ -278,6 +286,7 @@ DecisionTree.verboseTraining
 ```
 
 These are the syntactic elements of this member access:
+
 * The receiver, which is the name of the class (here `DecisionTree`)
 * A dot.
 * The name of the static member of the class (here `verboseTraining`)
@@ -293,6 +302,7 @@ DecisionTree().maxDepth
 ```
 
 We now take apart the syntax again:
+
 * The receiver, here a [call](#calls) of the constructor of the class `DecisionTree`. This creates an instance of this class.
 * A dot.
 * The name of the instance member (here `maxDepth`).
@@ -329,6 +339,7 @@ SvmKernel.Linear
 ```
 
 These are the elements of the syntax:
+
 * The receiver, which is the name of the [enum][enums] (here `SvmKernel`).
 * A dot.
 * The name of the [variant][enum-variants] (here `Linear`).
@@ -352,6 +363,7 @@ divideWithRemainder(12, 5).remainder
 ```
 
 Here are the syntactic elements:
+
 * The receiver, which is a [call](#calls).
 * A dot.
 * The name of the result (here `remainder`).
@@ -395,6 +407,7 @@ step printFirst(vararg values: Int) {
 ```
 
 These are the elements of the syntax:
+
 * The name of the variadic parameter (here `values`).
 * An opening square bracket.
 * The index, which is an expression that evaluates to an integer. The first element has index 0.
@@ -425,6 +438,7 @@ step myStep(vararg regressions: LinearRegression) {
 This step is called `myStep` and has a [variadic parameter][variadic-parameters] `regressions` of type `LinearRegression`. This means we can pass an arbitrary number of instances of `LinearRegression` to the step when we [call](#calls) it.
 
 In the body of the step we then
+
 1. access the first instance that was pass using an [indexed access](#indexed-accesses),
 2. access the instance method `drawAsGraph` of this instance using a [member access](#member-accesses),
 3. [call](#calls) this method.
@@ -492,6 +506,7 @@ intListOf(1, 4, 11).filter(
 ```
 
 These are the syntactic elements:
+
 * A list of [parameters][parameters], which is enclosed in parentheses. Individual parameters are separated by commas.
 * An arrow `->`.
 * The expression that should be returned.

--- a/docs/DSL/workflow-language/statements.md
+++ b/docs/DSL/workflow-language/statements.md
@@ -1,10 +1,12 @@
 # Statements
 
 Statements are used in the [workflow language][workflow-language] to run a specific action. Safe-DS supports only two type of statements, namely
+
 * [expression statements](#expression-statements), which are used to evaluate an expression exactly once and discard any results, and
 * [assignments](#assignments), which also evaluate an expression exactly once, but can then [assign selected results to placeholders](#declaring-placeholders) or [assign them to own results](#yielding-results).
 
 Other types of statements such as
+
 * if-statements to conditionally execute code or
 * while-statements to repeatedly execute code
 
@@ -19,6 +21,7 @@ print("Hello, world!");
 ```
 
 As we can see here, an expression statement has the following syntactic elements:
+
 * The [expression][expressions] to evaluate.
 * A semicolon at the end.
 
@@ -72,6 +75,7 @@ step trulyRandomInt() -> result: Int {
 ```
 
 The assignment here has the following syntactic elements:
+
 * The keyword `yield`, which indicates that we want to assign to a result.
 * The name of the result, here `greeting`. This must be identical to one of the names of a declared result in the header of the step.
 * An `=` sign.
@@ -89,6 +93,7 @@ Similar syntax is used to yield results of [block lambdas][block-lambdas]. The d
 ```
 
 The assignment here has the following syntactic elements:
+
 * The keyword `yield`, which indicates that we want to declare a result.
 * The name of the result, here `result`. This can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `lowerCamelCase` for the names of results.
 * An `=` sign.
@@ -124,7 +129,6 @@ Let us sum up the complete syntax of an assignment:
 * An `=` sign.
 * The expression to evaluate (right-hand side).
 * A semicolon at the end.
-
 
 **There must be at most as many assignees on the left-hand side as the right-hand side has results.** For everything but calls this means only a single assignee can be specified. For calls it depends on the number of declared [results][results] of the callee.
 

--- a/docs/DSL/workflow-language/statements.md
+++ b/docs/DSL/workflow-language/statements.md
@@ -2,13 +2,13 @@
 
 Statements are used in the [workflow language][workflow-language] to run a specific action. Safe-DS supports only two type of statements, namely
 
-* [expression statements](#expression-statements), which are used to evaluate an expression exactly once and discard any results, and
-* [assignments](#assignments), which also evaluate an expression exactly once, but can then [assign selected results to placeholders](#declaring-placeholders) or [assign them to own results](#yielding-results).
+- [expression statements](#expression-statements), which are used to evaluate an expression exactly once and discard any results, and
+- [assignments](#assignments), which also evaluate an expression exactly once, but can then [assign selected results to placeholders](#declaring-placeholders) or [assign them to own results](#yielding-results).
 
 Other types of statements such as
 
-* if-statements to conditionally execute code or
-* while-statements to repeatedly execute code
+- if-statements to conditionally execute code or
+- while-statements to repeatedly execute code
 
 are not planned since we want to keep the language small and easy to learn. Moreover, we want to refrain from developing yet another general-purpose programming language. Instead, code that depends on such features can be implemented in Python, integrated into Safe-DS using the [stub language][stub-language], and called in a Safe-DS program using the provided statements.
 
@@ -22,8 +22,8 @@ print("Hello, world!");
 
 As we can see here, an expression statement has the following syntactic elements:
 
-* The [expression][expressions] to evaluate.
-* A semicolon at the end.
+- The [expression][expressions] to evaluate.
+- A semicolon at the end.
 
 ## Assignments
 
@@ -41,11 +41,11 @@ val one = 1;
 
 This assignment to a placeholder has the following syntactic elements:
 
-* The keyword `val`, which indicates that we want to declare a placeholder.
-* The name of the placeholder, here `one`. This can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `lowerCamelCase` for the names of placeholders.
-* An `=` sign.
-* The expression to evaluate (right-hand side).
-* A semicolon at the end.
+- The keyword `val`, which indicates that we want to declare a placeholder.
+- The name of the placeholder, here `one`. This can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `lowerCamelCase` for the names of placeholders.
+- An `=` sign.
+- The expression to evaluate (right-hand side).
+- A semicolon at the end.
 
 #### References to Placeholder
 
@@ -76,11 +76,11 @@ step trulyRandomInt() -> result: Int {
 
 The assignment here has the following syntactic elements:
 
-* The keyword `yield`, which indicates that we want to assign to a result.
-* The name of the result, here `greeting`. This must be identical to one of the names of a declared result in the header of the step.
-* An `=` sign.
-* The expression to evaluate (right-hand side).
-* A semicolon at the end.
+- The keyword `yield`, which indicates that we want to assign to a result.
+- The name of the result, here `greeting`. This must be identical to one of the names of a declared result in the header of the step.
+- An `=` sign.
+- The expression to evaluate (right-hand side).
+- A semicolon at the end.
 
 #### Declare Results of Block Lambdas
 
@@ -94,11 +94,11 @@ Similar syntax is used to yield results of [block lambdas][block-lambdas]. The d
 
 The assignment here has the following syntactic elements:
 
-* The keyword `yield`, which indicates that we want to declare a result.
-* The name of the result, here `result`. This can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `lowerCamelCase` for the names of results.
-* An `=` sign.
-* The expression to evaluate (right-hand side).
-* A semicolon at the end.
+- The keyword `yield`, which indicates that we want to declare a result.
+- The name of the result, here `result`. This can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `lowerCamelCase` for the names of results.
+- An `=` sign.
+- The expression to evaluate (right-hand side).
+- A semicolon at the end.
 
 ### Ignoring Results
 
@@ -122,13 +122,14 @@ step createModel(fullDataset: Dataset) -> trainedModel: Model {
 ```
 
 Let us sum up the complete syntax of an assignment:
-* A comma-separated list of assignees, possibly with a trailing comma (left-hand side). Each entry is one of
-  * [Placeholder](#declaring-placeholders)
-  * [Yield](#yielding-results)
-  * [Wildcard](#ignoring-results)
-* An `=` sign.
-* The expression to evaluate (right-hand side).
-* A semicolon at the end.
+
+- A comma-separated list of assignees, possibly with a trailing comma (left-hand side). Each entry is one of
+  - [Placeholder](#declaring-placeholders)
+  - [Yield](#yielding-results)
+  - [Wildcard](#ignoring-results)
+- An `=` sign.
+- The expression to evaluate (right-hand side).
+- A semicolon at the end.
 
 **There must be at most as many assignees on the left-hand side as the right-hand side has results.** For everything but calls this means only a single assignee can be specified. For calls it depends on the number of declared [results][results] of the callee.
 

--- a/docs/DSL/workflow-language/steps.md
+++ b/docs/DSL/workflow-language/steps.md
@@ -13,6 +13,7 @@ step loadMovieRatingsSample() {}
 ```
 
 This declaration of a step has the following syntactic elements:
+
 * The keyword `step`.
 * The name of the step, here `loadMovieRatingsSample`. This can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `lowerCamelCase` for the names of steps.
 * The list of parameters (i.e. inputs) of the step. This is delimited by parentheses. In the example above, the step has no parameters.
@@ -100,7 +101,7 @@ The order of the [result declarations](#result-declaration) does not need to mat
 
 ## Visibility
 
-By default a step can be [imported][imports] in any other file and reused there. We say they have `public` visibility. However, it is possible to restrict the visibility of a step with modifiers:
+By default, a step can be [imported][imports] in any other file and reused there. We say they have `public` visibility. However, it is possible to restrict the visibility of a step with modifiers:
 
 ```txt
 internal step internalStep() {}
@@ -112,7 +113,7 @@ The step `internalStep` is only visible in files with the same [package][package
 
 ## Calling a Step
 
-Inside of a [workflow][workflows], another step, or a [lambda][lambdas] we can then [call][calls] a step, which means the step is executed when the call is reached: The results of a step can then be used as needed. In the following example, where we call the step `loadMovieRatingsSample` that we defined above, we [assign the results to placeholders][assignments-to-placeholders]:
+Inside a [workflow][workflows], another step, or a [lambda][lambdas] we can then [call][calls] a step, which means the step is executed when the call is reached: The results of a step can then be used as needed. In the following example, where we call the step `loadMovieRatingsSample` that we defined above, we [assign the results to placeholders][assignments-to-placeholders]:
 
 ```txt
 val features, val target = loadMovieRatingsSample(nInstances = 1000);

--- a/docs/DSL/workflow-language/steps.md
+++ b/docs/DSL/workflow-language/steps.md
@@ -14,14 +14,15 @@ step loadMovieRatingsSample() {}
 
 This declaration of a step has the following syntactic elements:
 
-* The keyword `step`.
-* The name of the step, here `loadMovieRatingsSample`. This can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `lowerCamelCase` for the names of steps.
-* The list of parameters (i.e. inputs) of the step. This is delimited by parentheses. In the example above, the step has no parameters.
-* The _body_ of the step, which contains the [statements][statements] that should be run when the step is [called](#calling-a-step). The body is delimited by curly braces. In this example, the body is empty, so running this step does nothing.
+- The keyword `step`.
+- The name of the step, here `loadMovieRatingsSample`. This can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `lowerCamelCase` for the names of steps.
+- The list of parameters (i.e. inputs) of the step. This is delimited by parentheses. In the example above, the step has no parameters.
+- The _body_ of the step, which contains the [statements][statements] that should be run when the step is [called](#calling-a-step). The body is delimited by curly braces. In this example, the body is empty, so running this step does nothing.
 
 ### Parameters
 
 To make a step configurable, add [parameters][parameters] (inputs). We will first show how to [declare parameters](#parameter-declaration) and afterwards how to [refer to them](#references-to-parameters) in the body of the step.
+
 #### Parameter Declaration
 
 Parameters must be declared in the header of the step so [callers](#calling-a-step) know they are expected to pass them as an argument, and so we can [use them](#references-to-parameters) in the body of the step.
@@ -79,7 +80,6 @@ More information about the declaration of results can be found in the [linked do
 #### Assigning to Results
 
 Currently, the program will not compile since we never assigned a value to these results. This can be done with an [assignment][assignments] and the `yield` keyword:
-
 
 ```txt
 step loadMovieRatingsSample(nInstances: Int) -> (features: Dataset, target: Dataset) {

--- a/docs/DSL/workflow-language/workflows.md
+++ b/docs/DSL/workflow-language/workflows.md
@@ -13,6 +13,7 @@ workflow predictSpeed {}
 ```
 
 This declaration of a workflow has the following syntactic elements:
+
 * The keyword `workflow`.
 * The name of the workflow, here `predictSpeed`, which can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `lowerCamelCase` for the names of workflows.
 * The body of the workflow, which contains the [statements][statements] that should be run when the workflow is executed. The body is delimited by curly braces. In this example, the body is empty, so running this workflow does nothing.

--- a/docs/DSL/workflow-language/workflows.md
+++ b/docs/DSL/workflow-language/workflows.md
@@ -14,9 +14,9 @@ workflow predictSpeed {}
 
 This declaration of a workflow has the following syntactic elements:
 
-* The keyword `workflow`.
-* The name of the workflow, here `predictSpeed`, which can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `lowerCamelCase` for the names of workflows.
-* The body of the workflow, which contains the [statements][statements] that should be run when the workflow is executed. The body is delimited by curly braces. In this example, the body is empty, so running this workflow does nothing.
+- The keyword `workflow`.
+- The name of the workflow, here `predictSpeed`, which can be any combination of upper- and lowercase letters, underscores, and numbers, as long as it does not start with a number. However, we suggest to use `lowerCamelCase` for the names of workflows.
+- The body of the workflow, which contains the [statements][statements] that should be run when the workflow is executed. The body is delimited by curly braces. In this example, the body is empty, so running this workflow does nothing.
 
 ### Statements
 

--- a/docs/Development/how-to-add-a-new-language-concept.md
+++ b/docs/Development/how-to-add-a-new-language-concept.md
@@ -63,24 +63,24 @@
 
 <!-- Links -->
 
-[experimental-sds-api]: ../../DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/utils/MarkerAnnotations.kt
-[safeds.ecore]: ../../DSL/com.larsreimann.safeds/model/SafeDS.ecore
-[safeds.genmodel]: ../../DSL/com.larsreimann.safeds/model/SafeDS.genmodel
-[grammar-tests]: ../../DSL/com.larsreimann.safeds/src/test/resources/grammar
-[safeds.xtext]: ../../DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/SafeDS.xtext
-[converter-tests]: ../../DSL/com.larsreimann.safeds/src/test/kotlin/com/larsreimann/safeds/conversion
-[converters]: ../../DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/conversion
-[scoping-tests]: ../../DSL/com.larsreimann.safeds/src/test/kotlin/com/larsreimann/safeds/scoping/ScopingTest.kt
-[local-scope-provider]: ../../DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/scoping/SafeDSScopeProvider.kt
-[resource-description-strategy]: ../../DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/scoping/SafeDSResourceDescriptionStrategy.kt
-[static-analysis]: ../../DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/staticAnalysis
-[validation-tests]: ../../DSL/com.larsreimann.safeds/src/test/resources/validation
-[validators]: ../../DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/validation
-[constants]: ../../DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/constant
-[creators]: ../../DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/emf/Creators.kt
-[shortcuts]: ../../DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/emf/SimpleShortcuts.kt
-[generator-tests]: ../../DSL/com.larsreimann.safeds/src/test/resources/generator
-[generator]: ../../DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/generator/SafeDSGenerator.kt
-[formatting-tests]: ../../DSL/com.larsreimann.safeds/src/test/resources/formatting
-[formatting]: ../../DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/formatting2/SafeDSFormatter.kt
-[tutorial]: docs/../../DSL/README.md
+[experimental-sds-api]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/utils/MarkerAnnotations.kt
+[safeds.ecore]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/com.larsreimann.safeds/model/SafeDS.ecore
+[safeds.genmodel]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/com.larsreimann.safeds/model/SafeDS.genmodel
+[grammar-tests]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/com.larsreimann.safeds/src/test/resources/grammar
+[safeds.xtext]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/SafeDS.xtext
+[converter-tests]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/com.larsreimann.safeds/src/test/kotlin/com/larsreimann/safeds/conversion
+[converters]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/conversion
+[scoping-tests]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/com.larsreimann.safeds/src/test/kotlin/com/larsreimann/safeds/scoping/ScopingTest.kt
+[local-scope-provider]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/scoping/SafeDSScopeProvider.kt
+[resource-description-strategy]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/scoping/SafeDSResourceDescriptionStrategy.kt
+[static-analysis]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/staticAnalysis
+[validation-tests]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/com.larsreimann.safeds/src/test/resources/validation
+[validators]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/validation
+[constants]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/constant
+[creators]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/emf/Creators.kt
+[shortcuts]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/emf/SimpleShortcuts.kt
+[generator-tests]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/com.larsreimann.safeds/src/test/resources/generator
+[generator]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/generator/SafeDSGenerator.kt
+[formatting-tests]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/com.larsreimann.safeds/src/test/resources/formatting
+[formatting]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/com.larsreimann.safeds/src/main/kotlin/com/larsreimann/safeds/formatting2/SafeDSFormatter.kt
+[tutorial]: ../DSL/README.md

--- a/docs/Development/how-to-prepare-a-release.md
+++ b/docs/Development/how-to-prepare-a-release.md
@@ -8,8 +8,7 @@
         // ...
     }
     ```
-
-2. Bump the version of the VS Code extension in [package.json][vscode-package-json]:
+1. Bump the version of the VS Code extension in [package.json][vscode-package-json]:
     ```json5
     {
         // ...
@@ -17,29 +16,29 @@
         // ...
     }
     ```
-3. Run this command to also update the associated `package-lock.json` file:
+1. Run this command to also update the associated `package-lock.json` file:
     ```sh
     cd DSL/com.larsreimann.safeds.vscode
     npm i
     ```
-4. Bump the version of the standard library in [safe-ds/pyproject.toml][stdlib-pyproject-toml]:
+1. Bump the version of the standard library in [safe-ds/pyproject.toml][stdlib-pyproject-toml]:
     ```toml
     [tool.poetry]
     # ...
     version = "1.0.0"
     # ...
     ```
-5. Bump the version of the runner in [safe-ds-runner/pyproject.toml][runner-pyproject-toml]:
+1. Bump the version of the runner in [safe-ds-runner/pyproject.toml][runner-pyproject-toml]:
     ```toml
     [tool.poetry]
     # ...
     version = "1.0.0"
     # ...
     ```
-6. Commit the changes in a new branch.
-7. Create a pull request.
-8. Merge the pull request into main.
-9. Create a release on GitHub.
+1. Commit the changes in a new branch.
+1. Create a pull request.
+1. Merge the pull request into main.
+1. Create a release on GitHub.
 
 [main-build-gradle]: ../../DSL/build.gradle.kts
 

--- a/docs/Development/how-to-prepare-a-release.md
+++ b/docs/Development/how-to-prepare-a-release.md
@@ -12,7 +12,7 @@
     ```json5
     {
         // ...
-        "version": "1.0.0",
+        version: '1.0.0',
         // ...
     }
     ```
@@ -41,9 +41,6 @@
 1. Create a release on GitHub.
 
 [main-build-gradle]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/build.gradle.kts
-
 [vscode-package-json]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/com.larsreimann.safeds.vscode/package.json
-
 [stdlib-pyproject-toml]: https://github.com/lars-reimann/Safe-DS/blob/main/Runtime/safe-ds/pyproject.toml
-
 [runner-pyproject-toml]: https://github.com/lars-reimann/Safe-DS/blob/main/Runtime/safe-ds-runner/pyproject.toml

--- a/docs/Development/how-to-prepare-a-release.md
+++ b/docs/Development/how-to-prepare-a-release.md
@@ -40,10 +40,10 @@
 1. Merge the pull request into main.
 1. Create a release on GitHub.
 
-[main-build-gradle]: ../../DSL/build.gradle.kts
+[main-build-gradle]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/build.gradle.kts
 
-[vscode-package-json]: ../../DSL/com.larsreimann.safeds.vscode/package.json
+[vscode-package-json]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/DSL/com.larsreimann.safeds.vscode/package.json
 
-[stdlib-pyproject-toml]: ../../Runtime/safe-ds/pyproject.toml
+[stdlib-pyproject-toml]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/Runtime/safe-ds/pyproject.toml
 
-[runner-pyproject-toml]: ../../Runtime/safe-ds-runner/pyproject.toml
+[runner-pyproject-toml]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/Runtime/safe-ds-runner/pyproject.toml

--- a/docs/Development/how-to-prepare-a-release.md
+++ b/docs/Development/how-to-prepare-a-release.md
@@ -42,8 +42,8 @@
 
 [main-build-gradle]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/build.gradle.kts
 
-[vscode-package-json]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/DSL/com.larsreimann.safeds.vscode/package.json
+[vscode-package-json]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/com.larsreimann.safeds.vscode/package.json
 
-[stdlib-pyproject-toml]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/Runtime/safe-ds/pyproject.toml
+[stdlib-pyproject-toml]: https://github.com/lars-reimann/Safe-DS/blob/main/Runtime/safe-ds/pyproject.toml
 
-[runner-pyproject-toml]: https://github.com/lars-reimann/Safe-DS/blob/main/DSL/Runtime/safe-ds-runner/pyproject.toml
+[runner-pyproject-toml]: https://github.com/lars-reimann/Safe-DS/blob/main/Runtime/safe-ds-runner/pyproject.toml

--- a/docs/Stdlib/API/safeds_lang.md
+++ b/docs/Stdlib/API/safeds_lang.md
@@ -1,292 +1,305 @@
 # Package `safeds.lang`
 
 ## <a name="class-Any"></a>Class `Any`
+
 The common superclass of all classes.
 
 **Constructor:** _Class has no constructor._
 
-
-----------
+---
 
 ## <a name="class-Boolean"></a>Class `Boolean`
+
 A truth value.
 
 **Constructor:** _Class has no constructor._
 
-
-----------
+---
 
 ## <a name="class-Float"></a>Class `Float`
+
 A floating-point number.
 
 **Constructor:** _Class has no constructor._
 
-
-----------
+---
 
 ## <a name="class-Int"></a>Class `Int`
+
 An integer.
 
 **Constructor:** _Class has no constructor._
 
-
-----------
+---
 
 ## <a name="class-Nothing"></a>Class `Nothing`
+
 The common subclass of all classes.
 
 **Constructor:** _Class has no constructor._
 
-
-----------
+---
 
 ## <a name="class-Number"></a>Class `Number`
+
 A number.
 
 **Constructor:** _Class has no constructor._
 
-
-----------
+---
 
 ## <a name="class-String"></a>Class `String`
+
 Some text.
 
 **Constructor:** _Class has no constructor._
 
-
 ## <a name="enum-AnnotationTarget"></a>Enum `AnnotationTarget`
+
 The declaration types that can be targeted by annotations.
+
 ### Enum Variant `Annotation`
+
 The annotation can be called on annotations.
 
 **Parameters:** _None expected._
 
-
 ### Enum Variant `Attribute`
+
 The annotation can be called on attributes.
 
 **Parameters:** _None expected._
 
-
 ### Enum Variant `Class`
+
 The annotation can be called on classes.
 
 **Parameters:** _None expected._
 
-
 ### Enum Variant `CompilationUnit`
+
 The annotation can be called on compilation units (i.e. files).
 
 **Parameters:** _None expected._
 
-
 ### Enum Variant `Enum`
+
 The annotation can be called on enums.
 
 **Parameters:** _None expected._
 
-
 ### Enum Variant `EnumVariant`
+
 The annotation can be called on enum variants.
 
 **Parameters:** _None expected._
 
-
 ### Enum Variant `Function`
+
 The annotation can be called on functions.
 
 **Parameters:** _None expected._
 
-
 ### Enum Variant `Parameter`
+
 The annotation can be called on parameters.
 
 **Parameters:** _None expected._
 
-
 ### Enum Variant `Result`
+
 The annotation can be called on results.
 
 **Parameters:** _None expected._
 
-
 ### Enum Variant `Step`
+
 The annotation can be called on steps.
 
 **Parameters:** _None expected._
 
-
 ### Enum Variant `TypeParameter`
+
 The annotation can be called on type parameters.
 
 **Parameters:** _None expected._
 
-
 ### Enum Variant `Workflow`
+
 The annotation can be called on workflows.
 
 **Parameters:** _None expected._
 
-
-
 ## <a name="annotation-Constant"></a>Annotation `Constant`
+
 Values assigned to this parameter must be constant.
 
 **Valid targets:**
 
-* Parameter
+- Parameter
 
 ## <a name="annotation-Deprecated"></a>Annotation `Deprecated`
+
 The declaration should no longer be used.
 
 **Parameters:**
 
-* `alternative: String? = null` - What to use instead.
-* `reason: String? = null` - Why the declaration was deprecated.
-* `sinceVersion: String? = null` - When the declaration was deprecated.
-* `removalVersion: String? = null` - When the declaration will be removed.
+- `alternative: String? = null` - What to use instead.
+- `reason: String? = null` - Why the declaration was deprecated.
+- `sinceVersion: String? = null` - When the declaration was deprecated.
+- `removalVersion: String? = null` - When the declaration will be removed.
 
 **Valid targets:**
 
-* Annotation
-* Attribute
-* Class
-* Enum
-* EnumVariant
-* Function
-* Parameter
-* Result
-* Step
-* TypeParameter
+- Annotation
+- Attribute
+- Class
+- Enum
+- EnumVariant
+- Function
+- Parameter
+- Result
+- Step
+- TypeParameter
 
 ## <a name="annotation-Description"></a>Annotation `Description`
+
 The purpose of a declaration.
 
 **Parameters:**
 
-* `description: String` - The purpose of a declaration.
+- `description: String` - The purpose of a declaration.
 
 **Valid targets:**
 
-* Annotation
-* Attribute
-* Class
-* CompilationUnit
-* Enum
-* EnumVariant
-* Function
-* Parameter
-* Result
-* Step
-* TypeParameter
-* Workflow
+- Annotation
+- Attribute
+- Class
+- CompilationUnit
+- Enum
+- EnumVariant
+- Function
+- Parameter
+- Result
+- Step
+- TypeParameter
+- Workflow
 
 ## <a name="annotation-Experimental"></a>Annotation `Experimental`
+
 The declaration might change without a major version bump.
 
 **Valid targets:**
 
-* Annotation
-* Attribute
-* Class
-* Enum
-* EnumVariant
-* Function
-* Parameter
-* Result
-* Step
-* TypeParameter
+- Annotation
+- Attribute
+- Class
+- Enum
+- EnumVariant
+- Function
+- Parameter
+- Result
+- Step
+- TypeParameter
 
 ## <a name="annotation-Expert"></a>Annotation `Expert`
+
 This parameter should only be used by expert users.
 
 **Valid targets:**
 
-* Parameter
+- Parameter
 
 ## <a name="annotation-NoSideEffects"></a>Annotation `NoSideEffects`
+
 The function has no side effects.
 
 **Valid targets:**
 
-* Function
+- Function
 
 ## <a name="annotation-Pure"></a>Annotation `Pure`
+
 The function has no side effects and returns the same results for the same arguments.
 
 **Valid targets:**
 
-* Function
+- Function
 
 ## <a name="annotation-PythonModule"></a>Annotation `PythonModule`
+
 The qualified name of the corresponding Python module (default is the qualified name of the package).
 
 **Parameters:**
 
-* `qualifiedName: String` - The qualified name of the corresponding Python module.
+- `qualifiedName: String` - The qualified name of the corresponding Python module.
 
 **Valid targets:**
 
-* CompilationUnit
+- CompilationUnit
 
 ## <a name="annotation-PythonName"></a>Annotation `PythonName`
+
 The name of the corresponding API element in Python (default is the name of the declaration in the stubs).
 
 **Parameters:**
 
-* `name: String` - The name of the corresponding API element in Python.
+- `name: String` - The name of the corresponding API element in Python.
 
 **Valid targets:**
 
-* Attribute
-* Class
-* Enum
-* EnumVariant
-* Function
-* Parameter
-* Step
-* Workflow
+- Attribute
+- Class
+- Enum
+- EnumVariant
+- Function
+- Parameter
+- Step
+- Workflow
 
 ## <a name="annotation-Repeatable"></a>Annotation `Repeatable`
+
 The annotation can be called multiple times for the same declaration.
 
 **Valid targets:**
 
-* Annotation
+- Annotation
 
 ## <a name="annotation-Since"></a>Annotation `Since`
+
 The version in which a declaration was added.
 
 **Parameters:**
 
-* `version: String` - The version in which a declaration was added.
+- `version: String` - The version in which a declaration was added.
 
 **Valid targets:**
 
-* Annotation
-* Attribute
-* Class
-* CompilationUnit
-* Enum
-* EnumVariant
-* Function
-* Parameter
-* Result
-* Step
-* TypeParameter
-* Workflow
+- Annotation
+- Attribute
+- Class
+- CompilationUnit
+- Enum
+- EnumVariant
+- Function
+- Parameter
+- Result
+- Step
+- TypeParameter
+- Workflow
 
 ## <a name="annotation-Target"></a>Annotation `Target`
+
 The annotation can target these declaration types. If the @Target annotation is not used any declaration type can be targeted.
 
 **Parameters:**
 
-* `vararg targets: AnnotationTarget` - The valid targets.
+- `vararg targets: AnnotationTarget` - The valid targets.
 
 **Valid targets:**
 
-* Annotation
+- Annotation
 
-----------
+---
 
 **This file was created automatically. Do not change it manually!**

--- a/docs/Stdlib/API/safeds_lang.md
+++ b/docs/Stdlib/API/safeds_lang.md
@@ -1,32 +1,5 @@
 # Package `safeds.lang`
 
-## Table of Contents
-
-* Classes
-  * [`Any`](#class-Any)
-  * [`Boolean`](#class-Boolean)
-  * [`Float`](#class-Float)
-  * [`Int`](#class-Int)
-  * [`Nothing`](#class-Nothing)
-  * [`Number`](#class-Number)
-  * [`String`](#class-String)
-* Enums
-  * [`AnnotationTarget`](#enum-AnnotationTarget)
-* Annotations
-  * [`Constant`](#annotation-Constant)
-  * [`Deprecated`](#annotation-Deprecated)
-  * [`Description`](#annotation-Description)
-  * [`Expert`](#annotation-Expert)
-  * [`NoSideEffects`](#annotation-NoSideEffects)
-  * [`Pure`](#annotation-Pure)
-  * [`PythonModule`](#annotation-PythonModule)
-  * [`PythonName`](#annotation-PythonName)
-  * [`Repeatable`](#annotation-Repeatable)
-  * [`Since`](#annotation-Since)
-  * [`Target`](#annotation-Target)
-
-----------
-
 ## <a name="class-Any"></a>Class `Any`
 The common superclass of all classes.
 
@@ -160,18 +133,21 @@ The annotation can be called on workflows.
 Values assigned to this parameter must be constant.
 
 **Valid targets:**
+
 * Parameter
 
 ## <a name="annotation-Deprecated"></a>Annotation `Deprecated`
 The declaration should no longer be used.
 
 **Parameters:**
+
 * `alternative: String? = null` - What to use instead.
 * `reason: String? = null` - Why the declaration was deprecated.
 * `sinceVersion: String? = null` - When the declaration was deprecated.
 * `removalVersion: String? = null` - When the declaration will be removed.
 
 **Valid targets:**
+
 * Annotation
 * Attribute
 * Class
@@ -187,9 +163,11 @@ The declaration should no longer be used.
 The purpose of a declaration.
 
 **Parameters:**
+
 * `description: String` - The purpose of a declaration.
 
 **Valid targets:**
+
 * Annotation
 * Attribute
 * Class
@@ -203,40 +181,63 @@ The purpose of a declaration.
 * TypeParameter
 * Workflow
 
+## <a name="annotation-Experimental"></a>Annotation `Experimental`
+The declaration might change without a major version bump.
+
+**Valid targets:**
+
+* Annotation
+* Attribute
+* Class
+* Enum
+* EnumVariant
+* Function
+* Parameter
+* Result
+* Step
+* TypeParameter
+
 ## <a name="annotation-Expert"></a>Annotation `Expert`
 This parameter should only be used by expert users.
 
 **Valid targets:**
+
 * Parameter
 
 ## <a name="annotation-NoSideEffects"></a>Annotation `NoSideEffects`
 The function has no side effects.
 
 **Valid targets:**
+
 * Function
 
 ## <a name="annotation-Pure"></a>Annotation `Pure`
 The function has no side effects and returns the same results for the same arguments.
 
 **Valid targets:**
+
 * Function
 
 ## <a name="annotation-PythonModule"></a>Annotation `PythonModule`
 The qualified name of the corresponding Python module (default is the qualified name of the package).
 
 **Parameters:**
+
 * `qualifiedName: String` - The qualified name of the corresponding Python module.
 
 **Valid targets:**
+
 * CompilationUnit
 
 ## <a name="annotation-PythonName"></a>Annotation `PythonName`
 The name of the corresponding API element in Python (default is the name of the declaration in the stubs).
 
 **Parameters:**
+
 * `name: String` - The name of the corresponding API element in Python.
 
 **Valid targets:**
+
 * Attribute
 * Class
 * Enum
@@ -250,15 +251,18 @@ The name of the corresponding API element in Python (default is the name of the 
 The annotation can be called multiple times for the same declaration.
 
 **Valid targets:**
+
 * Annotation
 
 ## <a name="annotation-Since"></a>Annotation `Since`
 The version in which a declaration was added.
 
 **Parameters:**
+
 * `version: String` - The version in which a declaration was added.
 
 **Valid targets:**
+
 * Annotation
 * Attribute
 * Class
@@ -276,9 +280,11 @@ The version in which a declaration was added.
 The annotation can target these declaration types. If the @Target annotation is not used any declaration type can be targeted.
 
 **Parameters:**
+
 * `vararg targets: AnnotationTarget` - The valid targets.
 
 **Valid targets:**
+
 * Annotation
 
 ----------


### PR DESCRIPTION
### Summary of Changes

* Put a blank line before lists so they get rendered properly
* Use full GitHub URLs to point to files outside the documentation to fix broken links
  * Downside: We now always point to the main branch
* Remove custom table of contents in auto-generated documentation for the DSL standard library
