### PR TITLE
fix: Table method remove_outliers() removes column names

### DIFF
--- a/Runtime/safe-ds/safe_ds/data/_table.py
+++ b/Runtime/safe-ds/safe_ds/data/_table.py
@@ -744,7 +744,7 @@ class Table:
             )
         ]
 
-        return Table(result)
+        return Table(result, self.schema)
 
     def __eq__(self, other: typing.Any) -> bool:
         if not isinstance(other, Table):

--- a/Runtime/safe-ds/tests/data/_table/test_remove_outliers.py
+++ b/Runtime/safe-ds/tests/data/_table/test_remove_outliers.py
@@ -13,9 +13,11 @@ def test_remove_outliers_no_outliers() -> None:
             }
         )
     )
+    names = table.get_column_names()
     result = table.remove_outliers()
     assert result.count_rows() == 3
     assert result.count_columns() == 3
+    assert names == table.get_column_names()
 
 
 def test_remove_outliers_with_outliers() -> None:


### PR DESCRIPTION
Closes #356.

### Summary of Changes

The table schema is kept when removing_outliers.

### Testing Instructions

```
table = # define Table()
names = table.get_column_names()
table = table.remove_outliers()
assert names = table.get_column_names() # now returns as true
```