### PR TITLE
docs: replace "Machine Learning" with data science

### DIFF
--- a/docs/DSL/README.md
+++ b/docs/DSL/README.md
@@ -2,7 +2,7 @@
 
 The Safe-DS DSL is split into two main parts:
 
--   The _[pipeline language][pipeline-language]_ is used to solve specific Machine Learning problems. Unless you want to add functionality to Safe-DS, this sublanguage is all you need to learn. To use the pipeline language, create a file with the extension `.sdspipe`.
+-   The _[pipeline language][pipeline-language]_ is used to solve specific data science problems. Unless you want to add functionality to Safe-DS, this sublanguage is all you need to learn. To use the pipeline language, create a file with the extension `.sdspipe`.
 -   The _[stub language][stub-language]_ is used to integrate external code written in Python into Safe-DS, so it can be used in the [pipeline language][pipeline-language]. The main purpose of this sublanguage is to define the [Safe-DS Standard Library (stdlib)][stdlib]. To use the stub language, create a file with the extension `.sdsstub`.
 
 [pipeline-language]: pipeline-language/README.md

--- a/docs/DSL/pipeline-language/README.md
+++ b/docs/DSL/pipeline-language/README.md
@@ -1,11 +1,11 @@
 # Pipeline Language
 
-The pipeline language is the part of the Safe-DS DSL that is designed to solve specific machine learning problems. It has the following concepts:
+The pipeline language is the part of the Safe-DS DSL that is designed to solve specific data science problems. It has the following concepts:
 
 -   [Packages][packages] help avoid conflicts that could arise if two declarations have the same name.
 -   [Imports][imports] make declarations in other packages accessible.
--   [Pipelines][pipelines] define the entry point of a Machine Learning program.
--   [Steps][steps] encapsulate parts of a Machine Learning program and make them reusable.
+-   [Pipelines][pipelines] define the entry point of a data science program.
+-   [Steps][steps] encapsulate parts of a data science program and make them reusable.
 -   [Statements][statements] are the instructions that are executed as part of a [pipeline][pipelines], [step][steps], or [block lambda][block-lambdas].
 -   [Expressions][expressions] are computations that produce some value.
 -   [Comments][comments] document the code.

--- a/docs/DSL/pipeline-language/steps.md
+++ b/docs/DSL/pipeline-language/steps.md
@@ -1,6 +1,6 @@
 # Steps
 
-Steps are used to extract a sequence of [statements][statements] from a Machine Learning program to give the sequence a name and make it reusable. In the following discussion we explain how to [declare a step](#declaring-a-step) and how to [call it](#calling-a-step).
+Steps are used to extract a sequence of [statements][statements] from a data science program to give the sequence a name and make it reusable. In the following discussion we explain how to [declare a step](#declaring-a-step) and how to [call it](#calling-a-step).
 
 ## Declaring a Step
 


### PR DESCRIPTION
### Summary of Changes

Replace the term "Machine Learning" with "data science" in the language documentation.
